### PR TITLE
Enhance Windows console support in cyberdriver.py by enabling ANSI es…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $toolDir = "$env:USERPROFILE\.cyberdriver"
 New-Item -ItemType Directory -Force -Path $toolDir
 
 # Download cyberdriver
-Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.14/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe"
+Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.15/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe"
 
 # Add to PATH if not already there
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -159,7 +159,7 @@ Configuration is stored in:
 The config file contains:
 ```json
 {
-  "version": "0.0.14",
+  "version": "0.0.15",
   "fingerprint": "uuid-v4-string"
 }
 ```


### PR DESCRIPTION
…cape sequences for colored output and updating version to 0.0.15. Add a new function to print a banner without colors for terminals that don't support ANSI. Update README with new version links.