### PR TITLE
Cursor/keyboard input timing dc3c

### DIFF
--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3409,16 +3409,15 @@ async def post_keyboard_type(payload: Dict[str, str]):
             # Ensure Caps Lock is OFF to prevent case inversion
             await _ensure_capslock_off()
 
-            # Run keyboard typing in a worker thread so long inputs don't block the event loop.
-            # This keeps tunnel I/O responsive while typing and reduces cascading timeouts.
+            # Execute typing on the request thread to preserve input-path behavior.
             if platform.system() == "Windows":
                 try:
-                    await asyncio.to_thread(_type_with_win32_sendinput, text)
+                    _type_with_win32_sendinput(text)
                 except Exception as e:
                     print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
-                    await asyncio.to_thread(pyautogui.typewrite, text)
+                    pyautogui.typewrite(text)
             else:
-                await asyncio.to_thread(pyautogui.typewrite, text)
+                pyautogui.typewrite(text)
 
             await _wait_for_typing_settle(text)
             app.state.keyboard_type_last_hash = text_hash

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2079,20 +2079,13 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 # Remote desktops (Citrix/RDP/VDI) can render injected keystrokes slightly after
 # key events are queued. We apply a fixed base delay plus a char-count-based
 # delay to reduce races with immediate follow-up actions/screenshots.
-# To prevent upstream request timeouts from causing duplicate retry typing,
-# this delay is capped by default. Set CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS=0
-# to disable the cap and use purely uncapped linear delay.
 TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
 TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
-TYPING_SETTLE_MAX_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS", 1.5)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
-    uncapped_delay = TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS)
-    if TYPING_SETTLE_MAX_SECONDS <= 0:
-        return max(0.0, uncapped_delay)
-    return max(0.0, min(uncapped_delay, TYPING_SETTLE_MAX_SECONDS))
+    return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
 
 
 async def _wait_for_typing_settle(text: str) -> None:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3409,15 +3409,17 @@ async def post_keyboard_type(payload: Dict[str, str]):
             # Ensure Caps Lock is OFF to prevent case inversion
             await _ensure_capslock_off()
 
-            # Execute typing on the request thread to preserve input-path behavior.
+            # Execute typing in a worker thread so long input doesn't block
+            # tunnel I/O on the main event loop. We still await completion,
+            # so the endpoint only returns after typing is actually done.
             if platform.system() == "Windows":
                 try:
-                    _type_with_win32_sendinput(text)
+                    await asyncio.to_thread(_type_with_win32_sendinput, text)
                 except Exception as e:
                     print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
-                    pyautogui.typewrite(text)
+                    await asyncio.to_thread(pyautogui.typewrite, text)
             else:
-                pyautogui.typewrite(text)
+                await asyncio.to_thread(pyautogui.typewrite, text)
 
             await _wait_for_typing_settle(text)
             app.state.keyboard_type_last_hash = text_hash

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2079,13 +2079,20 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 # Remote desktops (Citrix/RDP/VDI) can render injected keystrokes slightly after
 # key events are queued. We apply a fixed base delay plus a char-count-based
 # delay to reduce races with immediate follow-up actions/screenshots.
+# To prevent upstream request timeouts from causing duplicate retry typing,
+# this delay is capped by default. Set CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS=0
+# to disable the cap and use purely uncapped linear delay.
 TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
 TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
+TYPING_SETTLE_MAX_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS", 1.5)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
-    return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
+    uncapped_delay = TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS)
+    if TYPING_SETTLE_MAX_SECONDS <= 0:
+        return max(0.0, uncapped_delay)
+    return max(0.0, min(uncapped_delay, TYPING_SETTLE_MAX_SECONDS))
 
 
 async def _wait_for_typing_settle(text: str) -> None:
@@ -3254,6 +3261,7 @@ def _win32_send_key(scan_code: int, key_up: bool = False):
 def _type_with_win32_sendinput(text: str):
     """Type text using Windows SendInput API with hardware scan codes."""
     LSHIFT_SCANCODE = 0x2A
+    unsupported_chars: Dict[str, int] = {}
     
     for char in text:
         # Handle space specially when experimental mode is enabled
@@ -3282,7 +3290,7 @@ def _type_with_win32_sendinput(text: str):
             scan_code = SYMBOL_SCANCODES[char]
         
         if scan_code is None:
-            print(f"Warning: Character '{char}' not supported by scan code method, skipping")
+            unsupported_chars[char] = unsupported_chars.get(char, 0) + 1
             continue
         
         # Send key events
@@ -3292,6 +3300,17 @@ def _type_with_win32_sendinput(text: str):
         _win32_send_key(scan_code, key_up=True)
         if needs_shift:
             _win32_send_key(LSHIFT_SCANCODE, key_up=True)
+
+    if unsupported_chars:
+        total_unsupported = sum(unsupported_chars.values())
+        top_items = sorted(unsupported_chars.items(), key=lambda item: item[1], reverse=True)[:5]
+        summary = ", ".join(f"{repr(ch)} x{count}" for ch, count in top_items)
+        remaining = len(unsupported_chars) - len(top_items)
+        extra = f" (+{remaining} more)" if remaining > 0 else ""
+        print(
+            f"Warning: Skipped {total_unsupported} unsupported character(s) "
+            f"in scan code typing: {summary}{extra}"
+        )
 
 
 def _press_key_with_scancode(key: str, key_up: bool = False):

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3393,6 +3393,18 @@ async def post_keyboard_type(payload: Dict[str, str]):
 
     async with typing_lock:
         now = time.time()
+        # Re-check in-flight state after acquiring the lock to avoid a race where
+        # two identical requests pass the pre-lock check simultaneously.
+        inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
+        inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
+        if (
+            isinstance(inflight_hash, str)
+            and inflight_hash == text_hash
+            and (now - inflight_started) <= KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS
+        ):
+            print("Duplicate /keyboard/type payload detected after lock acquisition; skipping retry typing")
+            return {}
+
         last_hash = getattr(app.state, "keyboard_type_last_hash", None)
         last_completed = float(getattr(app.state, "keyboard_type_last_completed_at", 0.0) or 0.0)
         if (

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -42,6 +42,7 @@ import argparse
 import asyncio
 import base64
 import builtins
+import hashlib
 import json
 import math
 import os
@@ -2081,11 +2082,34 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 # delay to reduce races with immediate follow-up actions/screenshots.
 TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
 TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
+KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE", 0.004
+)
+KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS", 8.0
+)
+KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS", 5.0
+)
+KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS", 300.0, minimum=1.0
+)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
     return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
+
+
+def _hash_keyboard_type_text(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8", errors="replace")).hexdigest()
+
+
+def _estimate_keyboard_type_timeout_seconds(text: str) -> float:
+    char_count = len(text or "")
+    estimated_typing_seconds = char_count * KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE
+    settle_seconds = _compute_typing_settle_delay(text)
+    return max(30.0, estimated_typing_seconds + settle_seconds + KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS)
 
 
 async def _wait_for_typing_settle(text: str) -> None:
@@ -2103,6 +2127,11 @@ async def lifespan(app: FastAPI):
     """Manage application lifespan events."""
     # Startup
     app.state.start_time = time.time()
+    app.state.keyboard_type_lock = asyncio.Lock()
+    app.state.keyboard_type_inflight_hash = None
+    app.state.keyboard_type_inflight_started_at = 0.0
+    app.state.keyboard_type_last_hash = None
+    app.state.keyboard_type_last_completed_at = 0.0
     yield
     # Shutdown
     print("Shutting down...")
@@ -3341,23 +3370,63 @@ async def post_keyboard_type(payload: Dict[str, str]):
     text = payload.get("text")
     if not text:
         raise HTTPException(status_code=400, detail="Missing 'text' field")
-    
-    # Ensure Caps Lock is OFF to prevent case inversion
-    await _ensure_capslock_off()
-    
-    # On Windows: use native SendInput with scan codes (Citrix-compatible)
-    # On macOS/Linux: use PyAutoGUI
-    if platform.system() == "Windows":
-        try:
-            _type_with_win32_sendinput(text)
-            await _wait_for_typing_settle(text)
+    if not isinstance(text, str):
+        text = str(text)
+
+    text_hash = _hash_keyboard_type_text(text)
+
+    typing_lock: Optional[asyncio.Lock] = getattr(app.state, "keyboard_type_lock", None)
+    if typing_lock is None:
+        typing_lock = asyncio.Lock()
+        app.state.keyboard_type_lock = typing_lock
+
+    now = time.time()
+    inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
+    inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
+    if (
+        isinstance(inflight_hash, str)
+        and inflight_hash == text_hash
+        and (now - inflight_started) <= KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS
+    ):
+        print("Duplicate /keyboard/type payload received while identical request is in-flight; skipping retry typing")
+        return {}
+
+    async with typing_lock:
+        now = time.time()
+        last_hash = getattr(app.state, "keyboard_type_last_hash", None)
+        last_completed = float(getattr(app.state, "keyboard_type_last_completed_at", 0.0) or 0.0)
+        if (
+            isinstance(last_hash, str)
+            and last_hash == text_hash
+            and (now - last_completed) <= KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS
+        ):
+            print("Duplicate /keyboard/type payload received shortly after completion; skipping retry typing")
             return {}
-        except Exception as e:
-            print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
-    
-    # Fallback for non-Windows or if SendInput fails
-    pyautogui.typewrite(text)
-    await _wait_for_typing_settle(text)
+
+        app.state.keyboard_type_inflight_hash = text_hash
+        app.state.keyboard_type_inflight_started_at = now
+        try:
+            # Ensure Caps Lock is OFF to prevent case inversion
+            await _ensure_capslock_off()
+
+            # Run keyboard typing in a worker thread so long inputs don't block the event loop.
+            # This keeps tunnel I/O responsive while typing and reduces cascading timeouts.
+            if platform.system() == "Windows":
+                try:
+                    await asyncio.to_thread(_type_with_win32_sendinput, text)
+                except Exception as e:
+                    print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
+                    await asyncio.to_thread(pyautogui.typewrite, text)
+            else:
+                await asyncio.to_thread(pyautogui.typewrite, text)
+
+            await _wait_for_typing_settle(text)
+            app.state.keyboard_type_last_hash = text_hash
+            app.state.keyboard_type_last_completed_at = time.time()
+        finally:
+            app.state.keyboard_type_inflight_hash = None
+            app.state.keyboard_type_inflight_started_at = 0.0
+
     return {}
 
 
@@ -4829,6 +4898,7 @@ class TunnelClient:
             url += f"?{query}"
         
         # For PowerShell exec requests, extract timeout from body and use custom client
+        # For keyboard type requests, compute timeout based on text length
         # For all other requests, use the default client with 30s timeout
         use_custom_timeout = False
         request_timeout = 30.0
@@ -4840,6 +4910,15 @@ class TunnelClient:
                     # The local FastAPI will timeout the subprocess at exactly `timeout` seconds,
                     # so we need to wait slightly longer to receive that response 
                     request_timeout = float(payload["timeout"]) + 3.0  # 3s buffer for local processing
+                    use_custom_timeout = True
+            except Exception:
+                pass  # Fall back to default client if parsing fails
+        elif path == "/computer/input/keyboard/type" and body:
+            try:
+                payload = json.loads(body.decode('utf-8'))
+                text = payload.get("text")
+                if isinstance(text, str):
+                    request_timeout = _estimate_keyboard_type_timeout_seconds(text)
                     use_custom_timeout = True
             except Exception:
                 pass  # Fall back to default client if parsing fails


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the `/computer/input/keyboard/type` endpoint with in-flight deduplication, serialised typing via an `asyncio.Lock`, offloaded typing to worker threads (`asyncio.to_thread`), and a dynamic tunnel-client timeout proportional to text length. It also improves log quality in `_type_with_win32_sendinput` by batching per-character warnings into a single end-of-call summary.

**Key changes:**
- New `asyncio.Lock` (`keyboard_type_lock`) serialises concurrent typing requests; pre-lock and post-lock duplicate checks guard against same-text retry storms using both an in-flight hash and a recent-completion cache.
- `_type_with_win32_sendinput` and `pyautogui.typewrite` are now run in worker threads so long input no longer blocks the event loop.
- `_estimate_keyboard_type_timeout_seconds` computes a per-request read timeout for the tunnel client based on character count, replacing the flat 30-second default.
- Unsupported-character warnings in `_type_with_win32_sendinput` are now aggregated and emitted once per call instead of once per character.

**Issues found:**
- The tunnel-client timeout computed by `_estimate_keyboard_type_timeout_seconds` only covers this request's own typing duration. Because the new lock serialises all typing calls, a request queued behind a long operation will need to wait for the previous call to finish before it even starts — that wait time is not included in the timeout, risking premature `read` timeouts at the tunnel layer.
- The Windows SendInput → PyAutoGUI fallback can produce garbled output: if `_type_with_win32_sendinput` partially types text before raising, `pyautogui.typewrite` then retypes the full string, leaving the target application with duplicated partial input.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for the happy path, but the tunnel timeout undercount and partial-double-type fallback are real edge-case bugs that could produce incorrect behaviour under load or on Windows SendInput failure.
- The deduplication and serialisation logic is well-structured and the double-check (pre-lock + post-lock) pattern is correct. However, the computed tunnel timeout ignores lock queue wait time — a meaningful omission now that all typing is serialised — and the Windows fallback path can garble input if SendInput types partial text before failing. These are not hypothetical: they're reproducible with concurrent requests or certain special characters on Windows.
- Pay close attention to `cyberdriver.py` around `_estimate_keyboard_type_timeout_seconds` (line 2108) and the Windows SendInput fallback block (lines 3427–3432).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cyberdriver.py | Adds in-flight deduplication with an asyncio lock, batched unsupported-character logging, asyncio.to_thread offloading for typing, and a dynamic tunnel-client timeout for keyboard type requests. Two logic issues: the tunnel timeout doesn't account for lock queue wait, and the Windows SendInput → PyAutoGUI fallback can produce partial double-typed output. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TC as TunnelClient
    participant EP as POST /keyboard/type
    participant Lock as typing_lock
    participant State as app.state
    participant Thread as Worker Thread

    TC->>EP: POST (text, computed timeout)
    EP->>State: read inflight_hash (pre-lock check)
    alt duplicate in-flight
        EP-->>TC: {} (skipped)
    else not duplicate
        EP->>Lock: acquire
        Lock-->>EP: acquired
        EP->>State: re-check inflight_hash & last_hash
        alt duplicate detected post-lock
            EP-->>TC: {} (skipped)
            EP->>Lock: release
        else proceed
            EP->>State: set inflight_hash, inflight_started_at
            EP->>Thread: asyncio.to_thread(_type_with_win32_sendinput / pyautogui.typewrite)
            Thread-->>EP: done (or exception → fallback)
            EP->>EP: _wait_for_typing_settle
            EP->>State: set last_hash, last_completed_at
            EP->>State: clear inflight_hash (finally)
            EP->>Lock: release
            EP-->>TC: {}
        end
    end
```

<sub>Last reviewed commit: 47833c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->