### PR TITLE
Cyberdriver log consistency

### DIFF
--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -5176,12 +5176,14 @@ class TunnelClient:
 
 def run_server(port: int):
     """Run the FastAPI server."""
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    # Keep request logging single-sourced via Cyberdriver's own timestamped print lines.
+    uvicorn.run(app, host="0.0.0.0", port=port, access_log=False)
 
 
 async def run_server_async(port: int):
     """Run the FastAPI server asynchronously."""
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="info")
+    # Keep request logging single-sourced via Cyberdriver's own timestamped print lines.
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="info", access_log=False)
     server = uvicorn.Server(config)
     await server.serve()
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2347,8 +2347,17 @@ async def global_exception_handler(request, exc):
 
 @app.middleware("http")
 async def disable_buffering(request, call_next):
-    """Middleware to ensure responses are not buffered."""
-    response = await call_next(request)
+    """Log every request once and ensure responses are not buffered."""
+    method = request.method
+    path = request.url.path
+    try:
+        response = await call_next(request)
+    except Exception:
+        # Keep one request outcome line even when downstream raises unexpectedly.
+        print(f"{method} {path} -> 500")
+        raise
+
+    print(f"{method} {path} -> {response.status_code}")
     # Add headers to disable any proxy buffering
     response.headers["X-Accel-Buffering"] = "no"
     response.headers["Cache-Control"] = "no-cache"
@@ -5022,7 +5031,6 @@ class TunnelClient:
                 async with httpx.AsyncClient(timeout=timeout_obj) as request_client:
                     async with request_client.stream(method, url, headers=request_headers, content=body) as response:
                         duration_ms = (time.time() - request_start) * 1000
-                        print(f"{method} {path} -> {response.status_code}")
                         debug_logger.request_forwarded(method, path, response.status_code, duration_ms)
                         
                         # Read the response body immediately to avoid buffering
@@ -5039,7 +5047,6 @@ class TunnelClient:
                 # Use default client for all other requests (30s timeout) 
                 async with client.stream(method, url, headers=request_headers, content=body) as response:
                     duration_ms = (time.time() - request_start) * 1000
-                    print(f"{method} {path} -> {response.status_code}")
                     debug_logger.request_forwarded(method, path, response.status_code, duration_ms)
                     
                     # Read the response body immediately to avoid buffering


### PR DESCRIPTION
Disable Uvicorn access logging to eliminate duplicate log lines for each request.

---
<p><a href="https://cursor.com/agents/bc-fb281acf-317c-4ee7-afd1-34a7e144495e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb281acf-317c-4ee7-afd1-34a7e144495e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Consolidates request logging to eliminate duplicates by centralizing all HTTP request logging in the middleware and disabling Uvicorn's built-in access logging.

**Key changes:**
- Added comprehensive request logging in the `disable_buffering` middleware that captures all requests and their final status codes
- Included exception handling to ensure logging occurs even when downstream processing fails unexpectedly
- Removed duplicate `print()` statements from `TunnelClient` request forwarding (detailed forwarding metrics via `debug_logger` remain intact)
- Disabled Uvicorn access logs with `access_log=False` in both `run_server()` and `run_server_async()`

The approach maintains a single source of truth for request logging while preserving detailed forwarding metrics for debugging purposes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Changes are well-contained to logging configuration with proper error handling included. The refactoring consolidates logging to a single location without altering business logic or request/response handling.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cyberdriver.py | Centralized request logging to middleware, removed duplicate print statements from TunnelClient, and disabled Uvicorn access logs with `access_log=False` |

</details>



<sub>Last reviewed commit: ed43e9a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->