### PR TITLE
Include request duration in single middleware log line

### DIFF
--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -5650,6 +5650,13 @@ async def run_join(host: str, port: int, secret: str, target_port: int, keepaliv
                    black_screen_check_interval: float = 30.0,
                    debug_enabled: bool = False):
     """Run both API server and tunnel client."""
+    # Ensure default transfer directory exists for file operations during join.
+    transfers_dir = pathlib.Path.home() / "CyberdeskTransfers"
+    try:
+        transfers_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        print(f"Warning: Failed to create transfer directory at {transfers_dir}: {e}")
+
     # Store connection info for use by update endpoint
     _set_connection_info(host, port)
     # Per-process marker used to gate tunnel-only internal endpoints.

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2350,14 +2350,17 @@ async def disable_buffering(request, call_next):
     """Log every request once and ensure responses are not buffered."""
     method = request.method
     path = request.url.path
+    request_start = time.perf_counter()
     try:
         response = await call_next(request)
     except Exception:
         # Keep one request outcome line even when downstream raises unexpectedly.
-        print(f"{method} {path} -> 500")
+        duration_ms = (time.perf_counter() - request_start) * 1000
+        print(f"{method} {path} -> 500 ({duration_ms:.1f}ms)")
         raise
 
-    print(f"{method} {path} -> {response.status_code}")
+    duration_ms = (time.perf_counter() - request_start) * 1000
+    print(f"{method} {path} -> {response.status_code} ({duration_ms:.1f}ms)")
     # Add headers to disable any proxy buffering
     response.headers["X-Accel-Buffering"] = "no"
     response.headers["Cache-Control"] = "no-cache"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enhances middleware logging by adding request duration timing and ensures the CyberdeskTransfers directory exists on startup.

- Added `time.perf_counter()` timing to middleware to track request duration in milliseconds
- Duration is included in both successful responses and exception cases for complete logging coverage
- Proactively creates `~/CyberdeskTransfers` directory at join startup with proper error handling

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- Both changes are clean, well-implemented, and straightforward. The middleware timing uses appropriate `time.perf_counter()` for accurate duration tracking, handles both success and exception paths correctly, and the directory creation uses idempotent operations with proper exception handling. No security vulnerabilities, logic errors, or breaking changes introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cyberdriver.py | Added request duration tracking to middleware logging and proactive CyberdeskTransfers directory creation |

</details>



<sub>Last reviewed commit: 7b569d4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->