### PR TITLE
v0.0.40: variable type waiting, timestamps, autocreate CyberdeskTransfers, shutdown cyberdriver endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ New-Item -ItemType Directory -Force -Path $toolDir
 
 # Download cyberdriver
 try {
-    Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.39/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe" -ErrorAction Stop
+    Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.40/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe" -ErrorAction Stop
 } catch {
     Write-Host "ERROR: Failed to download Cyberdriver. Please check your internet connection and try again." -ForegroundColor Red
     return
@@ -77,7 +77,7 @@ if (Test-Path "$toolDir\cyberdriver.exe") {
 
 ```bash
 # Choose version and target directory
-VERSION=0.0.39
+VERSION=0.0.40
 TOOL_DIR="$HOME/.cyberdriver"
 mkdir -p "$TOOL_DIR"
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2097,6 +2097,9 @@ KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS = _get_env_float(
 KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS = _get_env_float(
     "CYBERDRIVER_KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS", 20.0
 )
+KEYBOARD_TYPE_TEXT_HASH_FALLBACK_WINDOW_SECONDS = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_TEXT_HASH_FALLBACK_WINDOW_SECONDS", 5.0
+)
 KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS = _get_env_float(
     "CYBERDRIVER_KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS", 300.0, minimum=1.0
 )
@@ -3336,7 +3339,7 @@ def _type_with_win32_sendinput(text: str):
     LSHIFT_SCANCODE = 0x2A
     unsupported_chars: Dict[str, int] = {}
     inter_key_delay = 0.0
-    if len(text or "") >= max(0, WINDOWS_SENDINPUT_DELAY_THRESHOLD_CHARS):
+    if len(text or "") >= WINDOWS_SENDINPUT_DELAY_THRESHOLD_CHARS:
         inter_key_delay = max(0.0, WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS)
     
     for char in text:
@@ -3432,18 +3435,22 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
         text = str(text)
 
     text = _normalize_text_for_keyboard_typing(text)
-    text_hash = _hash_keyboard_type_text(text)
     idempotency_key_raw = request.headers.get("x-idempotency-key")
     idempotency_key = idempotency_key_raw.strip() if isinstance(idempotency_key_raw, str) else ""
-    # Use idempotency key for retry dedupe when available; otherwise fall back to
-    # payload hash for in-flight protection only.
-    dedupe_key = f"idem:{idempotency_key}" if idempotency_key else f"text:{text_hash}"
-    post_completion_dedupe_enabled = bool(idempotency_key)
-    estimated_timeout_seconds = _estimate_keyboard_type_timeout_seconds(text)
-    dedupe_window_seconds = max(
-        KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS,
-        min(120.0, estimated_timeout_seconds + 5.0),
-    )
+    # Use idempotency key for retry dedupe when available.
+    # For non-idempotent callers, keep a short text-hash fallback window so
+    # immediate HTTP-layer retries don't re-type text after completion.
+    if idempotency_key:
+        dedupe_key = f"idem:{idempotency_key}"
+        estimated_timeout_seconds = _estimate_keyboard_type_timeout_seconds(text)
+        post_completion_window_seconds = max(
+            KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS,
+            min(120.0, estimated_timeout_seconds + 5.0),
+        )
+    else:
+        text_hash = _hash_keyboard_type_text(text)
+        dedupe_key = f"text:{text_hash}"
+        post_completion_window_seconds = max(0.0, KEYBOARD_TYPE_TEXT_HASH_FALLBACK_WINDOW_SECONDS)
 
     typing_lock: Optional[asyncio.Lock] = getattr(app.state, "keyboard_type_lock", None)
     if typing_lock is None:
@@ -3478,10 +3485,10 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
         last_hash = getattr(app.state, "keyboard_type_last_hash", None)
         last_completed = float(getattr(app.state, "keyboard_type_last_completed_at", 0.0) or 0.0)
         if (
-            post_completion_dedupe_enabled
+            post_completion_window_seconds > 0
             and isinstance(last_hash, str)
             and last_hash == dedupe_key
-            and (now - last_completed) <= dedupe_window_seconds
+            and (now - last_completed) <= post_completion_window_seconds
         ):
             print("Duplicate /keyboard/type payload received shortly after completion; skipping retry typing")
             return {}

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3409,16 +3409,15 @@ async def post_keyboard_type(payload: Dict[str, str]):
             # Ensure Caps Lock is OFF to prevent case inversion
             await _ensure_capslock_off()
 
-            # Run keyboard typing in a worker thread so long inputs don't block the event loop.
-            # This keeps tunnel I/O responsive while typing and reduces cascading timeouts.
+            # Execute typing on the request thread to preserve input-path behavior.
             if platform.system() == "Windows":
                 try:
-                    await asyncio.to_thread(_type_with_win32_sendinput, text)
+                    _type_with_win32_sendinput(text)
                 except Exception as e:
                     print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
-                    await asyncio.to_thread(pyautogui.typewrite, text)
+                    pyautogui.typewrite(text)
             else:
-                await asyncio.to_thread(pyautogui.typewrite, text)
+                pyautogui.typewrite(text)
 
             await _wait_for_typing_settle(text)
             app.state.keyboard_type_last_hash = text_hash

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -1965,6 +1965,42 @@ pyautogui.PAUSE = 0
 # where display changes can trigger false positives
 pyautogui.FAILSAFE = False
 
+
+def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    """Parse a float env var with safe fallback and clamping."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        print(f"Warning: invalid {name}={raw!r}; using default {default}")
+        return default
+    return max(minimum, value)
+
+
+# Post-type settle delay:
+# Remote desktops (Citrix/RDP/VDI) can render injected keystrokes slightly after
+# key events are queued. A short char-count-based wait reduces races with immediate
+# follow-up actions/screenshots.
+TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
+TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
+TYPING_SETTLE_MAX_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS", 1.2)
+
+
+def _compute_typing_settle_delay(text: str) -> float:
+    char_count = len(text or "")
+    uncapped = TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS)
+    max_delay = max(TYPING_SETTLE_MAX_SECONDS, TYPING_SETTLE_BASE_SECONDS)
+    return max(0.0, min(uncapped, max_delay))
+
+
+async def _wait_for_typing_settle(text: str) -> None:
+    delay_seconds = _compute_typing_settle_delay(text)
+    if delay_seconds <= 0:
+        return
+    await asyncio.sleep(delay_seconds)
+
 # -----------------------------------------------------------------------------
 # Local API implementation
 # -----------------------------------------------------------------------------
@@ -3144,12 +3180,14 @@ async def post_keyboard_type(payload: Dict[str, str]):
     if platform.system() == "Windows":
         try:
             _type_with_win32_sendinput(text)
+            await _wait_for_typing_settle(text)
             return {}
         except Exception as e:
             print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
     
     # Fallback for non-Windows or if SendInput fails
     pyautogui.typewrite(text)
+    await _wait_for_typing_settle(text)
     return {}
 
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2502,6 +2502,18 @@ async def post_shutdown(request: Request):
         if not _is_request_from_active_tunnel(request):
             raise HTTPException(status_code=403, detail="Forbidden: tunnel-only endpoint")
 
+        # Parse request JSON only after auth so unauthenticated malformed payloads
+        # cannot bypass tunnel-only checks via FastAPI body validation.
+        payload: Optional[Dict[str, Any]] = None
+        try:
+            raw_payload = await request.body()
+            if raw_payload:
+                parsed_payload = json.loads(raw_payload.decode("utf-8"))
+                if isinstance(parsed_payload, dict):
+                    payload = parsed_payload
+        except Exception:
+            payload = None
+
         pid = os.getpid()
         reason = None
         source = "unknown"

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -117,6 +117,21 @@ def _prefix_log_line_with_utc_timestamp(text: str) -> str:
     return f"{prefix}[{_utc_now_iso()}] {body}"
 
 
+def _prefix_log_text_with_utc_timestamps(text: str) -> str:
+    """Prefix each non-empty line in a text block with a UTC timestamp."""
+    if "\n" not in text:
+        return _prefix_log_line_with_utc_timestamp(text)
+
+    lines = text.split("\n")
+    prefixed_lines: List[str] = []
+    for line in lines:
+        if line == "":
+            prefixed_lines.append(line)
+            continue
+        prefixed_lines.append(_prefix_log_line_with_utc_timestamp(line))
+    return "\n".join(prefixed_lines)
+
+
 @contextmanager
 def _suppress_print_timestamps():
     """Temporarily disable timestamp prefixing for system/UX output."""
@@ -155,15 +170,15 @@ def _print_with_utc_timestamp(*args, **kwargs):
 
     # If each argument can become its own line (e.g., sep="\n"), prefix each one.
     if "\n" in sep:
-        prefixed_args = [_prefix_log_line_with_utc_timestamp(text) for text in text_args]
+        prefixed_args = [_prefix_log_text_with_utc_timestamps(text) for text in text_args]
         _ORIGINAL_PRINT(*prefixed_args, **kwargs)
         return
 
-    # Otherwise render exactly one output line and prefix it once.
+    # Otherwise render the final output and prefix each non-empty line.
     rendered = sep.join(text_args)
     kwargs_single = dict(kwargs)
     kwargs_single.pop("sep", None)
-    _ORIGINAL_PRINT(_prefix_log_line_with_utc_timestamp(rendered), **kwargs_single)
+    _ORIGINAL_PRINT(_prefix_log_text_with_utc_timestamps(rendered), **kwargs_single)
 
 
 if getattr(builtins.print, "__name__", "") != "_print_with_utc_timestamp":
@@ -2165,6 +2180,16 @@ async def _wait_for_typing_settle(text: str) -> None:
         return
     await asyncio.sleep(delay_seconds)
 
+
+def _initialize_keyboard_type_state(target_app: FastAPI) -> None:
+    """Initialize keyboard typing dedupe state and lock."""
+    target_app.state.keyboard_type_lock = asyncio.Lock()
+    target_app.state.keyboard_type_inflight_hash = None
+    target_app.state.keyboard_type_inflight_started_at = 0.0
+    target_app.state.keyboard_type_last_hash = None
+    target_app.state.keyboard_type_last_completed_at = 0.0
+
+
 # -----------------------------------------------------------------------------
 # Local API implementation
 # -----------------------------------------------------------------------------
@@ -2174,11 +2199,7 @@ async def lifespan(app: FastAPI):
     """Manage application lifespan events."""
     # Startup
     app.state.start_time = time.time()
-    app.state.keyboard_type_lock = asyncio.Lock()
-    app.state.keyboard_type_inflight_hash = None
-    app.state.keyboard_type_inflight_started_at = 0.0
-    app.state.keyboard_type_last_hash = None
-    app.state.keyboard_type_last_completed_at = 0.0
+    _initialize_keyboard_type_state(app)
     yield
     # Shutdown
     print("Shutting down...")
@@ -2188,6 +2209,7 @@ async def lifespan(app: FastAPI):
     print("Cleanup complete")
 
 app = FastAPI(title="Cyberdriver", version=VERSION, lifespan=lifespan)
+_initialize_keyboard_type_state(app)
 
 
 def _log_error_and_check_mei(error: Exception, context: str = "") -> bool:
@@ -3446,10 +3468,7 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
     dedupe_key = f"idem:{idempotency_key}" if idempotency_key else None
     post_completion_window_seconds = KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS if idempotency_key else 0.0
 
-    typing_lock: Optional[asyncio.Lock] = getattr(app.state, "keyboard_type_lock", None)
-    if typing_lock is None:
-        typing_lock = asyncio.Lock()
-        app.state.keyboard_type_lock = typing_lock
+    typing_lock: asyncio.Lock = app.state.keyboard_type_lock
 
     now = time.time()
     inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
@@ -4189,6 +4208,21 @@ def _get_restart_count() -> int:
         return 0
 
 
+def _get_max_restarts() -> Optional[int]:
+    """Get optional max restart limit; None means unlimited retries."""
+    raw_value = str(os.environ.get("CYBERDRIVER_MAX_RESTARTS", "")).strip()
+    if not raw_value:
+        return None
+    try:
+        parsed = int(raw_value)
+    except (ValueError, TypeError):
+        print(f"Warning: Invalid CYBERDRIVER_MAX_RESTARTS={raw_value!r}; ignoring restart limit")
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
 def _restart_cyberdriver_process() -> bool:
     """
     Restart cyberdriver by spawning a new process and exiting the current one.
@@ -4215,6 +4249,19 @@ def _restart_cyberdriver_process() -> bool:
     RESTART_HISTORY_MAX_BYTES = 1 * 1024 * 1024  # Cap restart-history.log at 1MB
 
     restart_count = _get_restart_count() + 1
+    max_restarts = _get_max_restarts()
+
+    if max_restarts is not None and restart_count > max_restarts:
+        print(f"\n{'='*60}")
+        print("❌ RESTART LIMIT REACHED")
+        print(f"{'='*60}")
+        print(
+            f"Configured max restarts ({max_restarts}) exceeded "
+            f"after {restart_count - 1} restart attempts."
+        )
+        print("Set CYBERDRIVER_MAX_RESTARTS=0 to allow unlimited retries.")
+        print(f"{'='*60}\n")
+        sys.exit(1)
 
     if restart_count >= RESTART_WARNING_EVERY and restart_count % RESTART_WARNING_EVERY == 0:
         print(f"\n{'='*60}")

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -5176,12 +5176,14 @@ class TunnelClient:
 
 def run_server(port: int):
     """Run the FastAPI server."""
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    # Keep request logging single-sourced via Cyberdriver's own timestamped print lines.
+    uvicorn.run(app, host="0.0.0.0", port=port, access_log=False)
 
 
 async def run_server_async(port: int):
     """Run the FastAPI server asynchronously."""
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="info")
+    # Keep request logging single-sourced via Cyberdriver's own timestamped print lines.
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="info", access_log=False)
     server = uvicorn.Server(config)
     await server.serve()
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -5039,7 +5039,7 @@ class TunnelClient:
         query = meta.get("query", "")
         headers = meta.get("headers", {})
         request_headers = dict(headers) if isinstance(headers, dict) else {}
-        if self.internal_request_token:
+        if self.internal_request_token and path == "/internal/shutdown":
             request_headers[TUNNEL_INTERNAL_REQUEST_HEADER] = self.internal_request_token
         
         # Check for idempotency key (case-insensitive header lookup)

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3610,6 +3610,12 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
                     await typing_task
                 except Exception as typing_exc:
                     print(f"Warning: typing task raised during cancellation: {typing_exc}")
+                else:
+                    # If typing completed despite client disconnect, still mark
+                    # post-completion dedupe state before re-raising cancellation.
+                    if dedupe_key:
+                        app.state.keyboard_type_last_hash = dedupe_key
+                        app.state.keyboard_type_last_completed_at = time.time()
                 raise
 
             await _wait_for_typing_settle(text)
@@ -4305,12 +4311,15 @@ def _get_max_restarts() -> Optional[int]:
     raw_value = str(os.environ.get("CYBERDRIVER_MAX_RESTARTS", "")).strip()
     if not raw_value:
         return None
+    raw_value_lower = raw_value.lower()
+    if raw_value_lower in ("unlimited", "none", "inf", "infinite"):
+        return None
     try:
         parsed = int(raw_value)
     except (ValueError, TypeError):
         print(f"Warning: Invalid CYBERDRIVER_MAX_RESTARTS={raw_value!r}; ignoring restart limit")
         return None
-    if parsed <= 0:
+    if parsed < 0:
         return None
     return parsed
 
@@ -4351,7 +4360,7 @@ def _restart_cyberdriver_process() -> bool:
             f"Configured max restarts ({max_restarts}) exceeded "
             f"after {restart_count - 1} restart attempts."
         )
-        print("Set CYBERDRIVER_MAX_RESTARTS=0 to allow unlimited retries.")
+        print("Set CYBERDRIVER_MAX_RESTARTS=-1 (or unset it) to allow unlimited retries.")
         print(f"{'='*60}\n")
         sys.exit(1)
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2256,7 +2256,6 @@ def _log_error_and_check_mei(error: Exception, context: str = "") -> bool:
     error_type = type(error).__name__
     
     # Always log the error - use both print and direct file logging
-    timestamp = _utc_now_iso()
     
     # Log to console (may not appear if stdout is captured)
     try:
@@ -2271,7 +2270,7 @@ def _log_error_and_check_mei(error: Exception, context: str = "") -> bool:
     try:
         log_path = get_config_dir() / "api-errors.log"
         with open(log_path, "a", encoding="utf-8") as f:
-            f.write(f"\n[{timestamp}] {context}\n")
+            f.write(f"\n[{_utc_now_iso()}] {context}\n")
             f.write(f"Type: {error_type}\n")
             f.write(f"Message: {error}\n")
     except Exception:
@@ -2347,7 +2346,6 @@ async def global_exception_handler(request, exc):
     from fastapi.responses import JSONResponse
     
     # Immediately log that we entered this handler
-    timestamp = _utc_now_iso()
     try:
         print(f"\n[GLOBAL EXCEPTION HANDLER]", flush=True)
         print(f"[GLOBAL EXCEPTION HANDLER] Exception type: {type(exc).__name__}", flush=True)
@@ -2360,7 +2358,7 @@ async def global_exception_handler(request, exc):
     try:
         log_path = get_config_dir() / "global-exception-handler.log"
         with open(log_path, "a", encoding="utf-8") as f:
-            f.write(f"\n[{timestamp}] GLOBAL EXCEPTION HANDLER INVOKED\n")
+            f.write(f"\n[{_utc_now_iso()}] GLOBAL EXCEPTION HANDLER INVOKED\n")
             f.write(f"Exception type: {type(exc).__name__}\n")
             f.write(f"Exception message: {exc}\n")
     except Exception:
@@ -4244,7 +4242,6 @@ async def post_powershell_exec(payload: Dict[str, Any]):
         return result
     except Exception as e:
         # Log the error with full details
-        timestamp = _utc_now_iso()
         error_type = type(e).__name__
         error_msg = str(e)
         
@@ -4260,7 +4257,7 @@ async def post_powershell_exec(payload: Dict[str, Any]):
         try:
             log_path = get_config_dir() / "powershell-errors.log"
             with open(log_path, "a", encoding="utf-8") as f:
-                f.write(f"\n[{timestamp}] POWERSHELL EXEC ERROR\n")
+                f.write(f"\n[{_utc_now_iso()}] POWERSHELL EXEC ERROR\n")
                 f.write(f"Type: {error_type}\n")
                 f.write(f"Message: {error_msg}\n")
                 f.write(f"Command: {command}\n")
@@ -6321,8 +6318,6 @@ def check_mei_health(context: str = "") -> bool:
             missing.append(d)
     
     if missing:
-        timestamp = _utc_now_iso()
-        
         # Get list of existing directories for debugging
         existing = []
         try:
@@ -6344,7 +6339,7 @@ def check_mei_health(context: str = "") -> bool:
             log_path = get_config_dir() / "mei-health-failures.log"
             with open(log_path, "a", encoding="utf-8") as f:
                 f.write(f"\n{'='*70}\n")
-                f.write(f"Timestamp: {timestamp}\n")
+                f.write(f"Timestamp: {_utc_now_iso()}\n")
                 f.write(f"Context: {context}\n")
                 f.write(f"_MEIPASS: {meipass}\n")
                 f.write(f"Missing directories: {missing}\n")

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2079,20 +2079,13 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 # Remote desktops (Citrix/RDP/VDI) can render injected keystrokes slightly after
 # key events are queued. We apply a fixed base delay plus a char-count-based
 # delay to reduce races with immediate follow-up actions/screenshots.
-# To prevent upstream request timeouts from causing duplicate retry typing,
-# this delay is capped by default. Set CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS=0
-# to disable the cap and use purely uncapped linear delay.
 TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
 TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
-TYPING_SETTLE_MAX_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS", 1.5)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
-    uncapped_delay = TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS)
-    if TYPING_SETTLE_MAX_SECONDS <= 0:
-        return max(0.0, uncapped_delay)
-    return max(0.0, min(uncapped_delay, TYPING_SETTLE_MAX_SECONDS))
+    return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
 
 
 async def _wait_for_typing_settle(text: str) -> None:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3409,15 +3409,17 @@ async def post_keyboard_type(payload: Dict[str, str]):
             # Ensure Caps Lock is OFF to prevent case inversion
             await _ensure_capslock_off()
 
-            # Execute typing on the request thread to preserve input-path behavior.
+            # Execute typing in a worker thread so long input doesn't block
+            # tunnel I/O on the main event loop. We still await completion,
+            # so the endpoint only returns after typing is actually done.
             if platform.system() == "Windows":
                 try:
-                    _type_with_win32_sendinput(text)
+                    await asyncio.to_thread(_type_with_win32_sendinput, text)
                 except Exception as e:
                     print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
-                    pyautogui.typewrite(text)
+                    await asyncio.to_thread(pyautogui.typewrite, text)
             else:
-                pyautogui.typewrite(text)
+                await asyncio.to_thread(pyautogui.typewrite, text)
 
             await _wait_for_typing_settle(text)
             app.state.keyboard_type_last_hash = text_hash

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -41,6 +41,7 @@ Usage:
 import argparse
 import asyncio
 import base64
+import builtins
 import json
 import math
 import os
@@ -77,7 +78,60 @@ from fastapi.responses import Response, JSONResponse
 import uvicorn
 import websockets
 from websockets.exceptions import ConnectionClosed, InvalidStatus
-from datetime import datetime
+from datetime import datetime, timezone
+
+# -----------------------------------------------------------------------------
+# UTC Timestamped Console Printing
+# -----------------------------------------------------------------------------
+
+_ISO_TIMESTAMP_PREFIX_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}T")
+_ORIGINAL_PRINT = builtins.print
+
+
+def _utc_now_iso() -> str:
+    """Return current UTC timestamp in ISO 8601 format with milliseconds."""
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _prefix_log_line_with_utc_timestamp(text: str) -> str:
+    """Prefix a log line with UTC timestamp while preserving leading blank lines."""
+    if not text:
+        return f"[{_utc_now_iso()}]"
+
+    leading_newlines = len(text) - len(text.lstrip("\n"))
+    prefix = text[:leading_newlines]
+    body = text[leading_newlines:]
+
+    # Keep in-place status/countdown updates untouched.
+    if body.startswith("\r"):
+        return text
+    # Avoid double-prefixing lines that already begin with an ISO timestamp.
+    if _ISO_TIMESTAMP_PREFIX_RE.match(body):
+        return text
+
+    if not body:
+        return f"{prefix}[{_utc_now_iso()}]"
+    return f"{prefix}[{_utc_now_iso()}] {body}"
+
+
+def _print_with_utc_timestamp(*args, **kwargs):
+    """Global print wrapper that adds UTC timestamps to regular log lines."""
+    end = kwargs.get("end", "\n")
+    # Preserve non-line-buffered prints used by countdown/progress output.
+    if end != "\n":
+        _ORIGINAL_PRINT(*args, **kwargs)
+        return
+
+    if not args:
+        _ORIGINAL_PRINT(f"[{_utc_now_iso()}]", **kwargs)
+        return
+
+    first_arg = _prefix_log_line_with_utc_timestamp(str(args[0]))
+    _ORIGINAL_PRINT(first_arg, *args[1:], **kwargs)
+
+
+if getattr(builtins.print, "__name__", "") != "_print_with_utc_timestamp":
+    builtins.print = _print_with_utc_timestamp
 
 # -----------------------------------------------------------------------------
 # Debug Logging System
@@ -119,7 +173,7 @@ class DebugLogger:
     
     def _get_log_file(self) -> pathlib.Path:
         """Get the current log file path, rotating by day."""
-        today = datetime.now().strftime("%Y-%m-%d")
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         if self._current_date != today:
             self._current_date = today
             self._log_file = self.log_dir / f"cyberdriver-{today}.log"
@@ -127,7 +181,7 @@ class DebugLogger:
     
     def _format_timestamp(self) -> str:
         """Get formatted timestamp for log entries."""
-        return datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        return _utc_now_iso()
     
     def _write(self, level: str, category: str, message: str, **context):
         """Write a log entry."""
@@ -775,7 +829,7 @@ def _setup_detached_stdio_if_configured():
             try:
                 self._path.parent.mkdir(parents=True, exist_ok=True)
                 with open(self._path, "w", encoding=self._encoding) as f:
-                    f.write(f"[{datetime.now().isoformat()}] Log truncated (max 10MB)\n")
+                    f.write(f"[{_utc_now_iso()}] Log truncated (max 10MB)\n")
                     f.flush()
             except Exception:
                 # If truncation fails, fall back to append to whatever exists.
@@ -821,7 +875,7 @@ def _setup_detached_stdio_if_configured():
                     try:
                         if encoded is None:
                             encoded = text.encode(self._encoding, errors="replace")
-                        marker_str = f"\n[{datetime.now().isoformat()}] Log chunk truncated to fit 10MB cap\n"
+                        marker_str = f"\n[{_utc_now_iso()}] Log chunk truncated to fit 10MB cap\n"
                         marker_b = marker_str.encode(self._encoding, errors="replace")
                         if len(marker_b) >= remaining:
                             tail_b = encoded[-remaining:]
@@ -880,7 +934,7 @@ def _setup_detached_stdio_if_configured():
         atexit.register(lambda: writer.close())
         sys.stdout = writer  # type: ignore[assignment]
         sys.stderr = writer  # type: ignore[assignment]
-        print(f"\n[{datetime.now().isoformat()}] Cyberdriver detached logging started")
+        print("\nCyberdriver detached logging started")
         sys.stdout.flush()
     except Exception:
         # If we can't redirect logs, just continue silently.
@@ -1481,7 +1535,7 @@ def write_pid_info(info: Dict[str, Any]) -> None:
         payload = dict(info)
         payload.setdefault("pid", os.getpid())
         payload.setdefault("version", VERSION)
-        payload.setdefault("started_at", datetime.now().isoformat())
+        payload.setdefault("started_at", _utc_now_iso())
         payload.setdefault("frozen", bool(getattr(sys, "frozen", False)))
         payload.setdefault("argv", sys.argv[:])
 
@@ -2038,7 +2092,7 @@ def _log_error_and_check_mei(error: Exception, context: str = "") -> bool:
     error_type = type(error).__name__
     
     # Always log the error - use both print and direct file logging
-    timestamp = datetime.now().isoformat()
+    timestamp = _utc_now_iso()
     
     # Log to console (may not appear if stdout is captured)
     try:
@@ -2129,7 +2183,7 @@ async def global_exception_handler(request, exc):
     from fastapi.responses import JSONResponse
     
     # Immediately log that we entered this handler
-    timestamp = datetime.now().isoformat()
+    timestamp = _utc_now_iso()
     try:
         print(f"\n[GLOBAL EXCEPTION HANDLER] {timestamp}", flush=True)
         print(f"[GLOBAL EXCEPTION HANDLER] Exception type: {type(exc).__name__}", flush=True)
@@ -2172,7 +2226,7 @@ async def global_exception_handler(request, exc):
         content={
             "error": type(exc).__name__,
             "message": error_msg,
-            "timestamp": datetime.now().isoformat()
+            "timestamp": _utc_now_iso()
         }
     )
 
@@ -3800,7 +3854,7 @@ async def post_powershell_exec(payload: Dict[str, Any]):
         return result
     except Exception as e:
         # Log the error with full details
-        timestamp = datetime.now().isoformat()
+        timestamp = _utc_now_iso()
         error_type = type(e).__name__
         error_msg = str(e)
         
@@ -3924,7 +3978,7 @@ def _restart_cyberdriver_process() -> bool:
     try:
         log_path = get_config_dir() / "restart-history.log"
         with open(log_path, "a", encoding="utf-8") as f:
-            f.write(f"\n[{datetime.now().isoformat()}] Restarting cyberdriver (attempt {restart_count}/{MAX_RESTARTS})\n")
+            f.write(f"\n[{_utc_now_iso()}] Restarting cyberdriver (attempt {restart_count}/{MAX_RESTARTS})\n")
             f.write(f"Command: {' '.join(cmd)}\n")
             f.write(f"PID (old): {os.getpid()}\n")
             f.write(f"_MEIPASS: {getattr(sys, '_MEIPASS', 'N/A')}\n")
@@ -4727,7 +4781,7 @@ class TunnelClient:
             debug_logger.error("REQUEST", f"Request failed: {error_msg}", method=method, path=path, duration_ms=f"{duration_ms:.1f}ms")
             
             # Log to console with full details
-            timestamp = datetime.now().isoformat()
+            timestamp = _utc_now_iso()
             print(f"\n{'='*60}", flush=True)
             print(f"[TUNNEL FORWARD ERROR] {timestamp}", flush=True)
             print(f"Error type: {error_type}", flush=True)
@@ -5814,7 +5868,7 @@ def check_mei_health(context: str = "") -> bool:
     
     if missing:
         from datetime import datetime
-        timestamp = datetime.now().isoformat()
+        timestamp = _utc_now_iso()
         
         # Get list of existing directories for debugging
         existing = []
@@ -5957,7 +6011,7 @@ def add_defender_exclusion() -> bool:
                 try:
                     log_path = get_config_dir() / "defender-exclusion.log"
                     with open(log_path, "a", encoding="utf-8") as f:
-                        f.write(f"\n[{datetime.now().isoformat()}] Failed to add Defender exclusion\n")
+                        f.write(f"\n[{_utc_now_iso()}] Failed to add Defender exclusion\n")
                         f.write(f"Path: {mei_parent}\n")
                         f.write(f"Error: {add_result.stderr}\n")
                 except:
@@ -6169,7 +6223,7 @@ def main():
         if info:
             old_pid = int(info.get("pid", -1))
             old_argv = info.get("argv", [])
-            timestamp = datetime.now().isoformat()
+            timestamp = _utc_now_iso()
             
             print_banner(mode="connecting")
             # Use yellow/warning color for visibility (if terminal supports it)

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2492,7 +2492,7 @@ def _is_request_from_active_tunnel(request: Request) -> bool:
 
 
 @app.post("/internal/shutdown")
-async def post_shutdown(request: Request, payload: Optional[Dict[str, Any]] = None):
+async def post_shutdown(request: Request):
     """Request cyberdriver to terminate itself.
 
     Intended for cloud control-plane use when a machine/session is being turned off.

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -42,7 +42,6 @@ import argparse
 import asyncio
 import base64
 import builtins
-import hashlib
 import json
 import math
 import os
@@ -2098,9 +2097,6 @@ KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS = _get_env_float(
 KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS = _get_env_float(
     "CYBERDRIVER_KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS", 20.0
 )
-KEYBOARD_TYPE_TEXT_HASH_FALLBACK_WINDOW_SECONDS = _get_env_float(
-    "CYBERDRIVER_KEYBOARD_TYPE_TEXT_HASH_FALLBACK_WINDOW_SECONDS", 5.0
-)
 KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS = _get_env_float(
     "CYBERDRIVER_KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS", 300.0, minimum=1.0
 )
@@ -2139,10 +2135,6 @@ def _compute_typing_settle_delay(text: str) -> float:
         + (linear_threshold * TYPING_SETTLE_PER_CHAR_SECONDS)
         + (overflow_chars * TYPING_SETTLE_LONG_TEXT_PER_CHAR_SECONDS),
     )
-
-
-def _hash_keyboard_type_text(text: str) -> str:
-    return hashlib.sha256((text or "").encode("utf-8", errors="replace")).hexdigest()
 
 
 def _normalize_text_for_keyboard_typing(text: str) -> str:
@@ -3438,20 +3430,9 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
     text = _normalize_text_for_keyboard_typing(text)
     idempotency_key_raw = request.headers.get("x-idempotency-key")
     idempotency_key = idempotency_key_raw.strip() if isinstance(idempotency_key_raw, str) else ""
-    # Use idempotency key for retry dedupe when available.
-    # For non-idempotent callers, keep a short text-hash fallback window so
-    # immediate HTTP-layer retries don't re-type text after completion.
-    if idempotency_key:
-        dedupe_key = f"idem:{idempotency_key}"
-        estimated_timeout_seconds = _estimate_keyboard_type_timeout_seconds(text)
-        post_completion_window_seconds = max(
-            KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS,
-            min(120.0, estimated_timeout_seconds + 5.0),
-        )
-    else:
-        text_hash = _hash_keyboard_type_text(text)
-        dedupe_key = f"text:{text_hash}"
-        post_completion_window_seconds = max(0.0, KEYBOARD_TYPE_TEXT_HASH_FALLBACK_WINDOW_SECONDS)
+    # Keep /keyboard/type retry dedupe simple: idempotency-key only.
+    dedupe_key = f"idem:{idempotency_key}" if idempotency_key else None
+    post_completion_window_seconds = KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS if idempotency_key else 0.0
 
     typing_lock: Optional[asyncio.Lock] = getattr(app.state, "keyboard_type_lock", None)
     if typing_lock is None:
@@ -3462,7 +3443,8 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
     inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
     inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
     if (
-        isinstance(inflight_hash, str)
+        dedupe_key
+        and isinstance(inflight_hash, str)
         and inflight_hash == dedupe_key
         and (now - inflight_started) <= KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS
     ):
@@ -3476,7 +3458,8 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
         inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
         inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
         if (
-            isinstance(inflight_hash, str)
+            dedupe_key
+            and isinstance(inflight_hash, str)
             and inflight_hash == dedupe_key
             and (now - inflight_started) <= KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS
         ):
@@ -3486,7 +3469,8 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
         last_hash = getattr(app.state, "keyboard_type_last_hash", None)
         last_completed = float(getattr(app.state, "keyboard_type_last_completed_at", 0.0) or 0.0)
         if (
-            post_completion_window_seconds > 0
+            dedupe_key
+            and post_completion_window_seconds > 0
             and isinstance(last_hash, str)
             and last_hash == dedupe_key
             and (now - last_completed) <= post_completion_window_seconds
@@ -3494,7 +3478,7 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
             print("Duplicate /keyboard/type payload received shortly after completion; skipping retry typing")
             return {}
 
-        app.state.keyboard_type_inflight_hash = dedupe_key
+        app.state.keyboard_type_inflight_hash = dedupe_key if dedupe_key else None
         app.state.keyboard_type_inflight_started_at = now
         try:
             # Ensure Caps Lock is OFF to prevent case inversion
@@ -3513,8 +3497,9 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
                 await asyncio.to_thread(pyautogui.typewrite, text)
 
             await _wait_for_typing_settle(text)
-            app.state.keyboard_type_last_hash = dedupe_key
-            app.state.keyboard_type_last_completed_at = time.time()
+            if dedupe_key:
+                app.state.keyboard_type_last_hash = dedupe_key
+                app.state.keyboard_type_last_completed_at = time.time()
         finally:
             app.state.keyboard_type_inflight_hash = None
             app.state.keyboard_type_inflight_started_at = 0.0

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -166,6 +166,11 @@ def _print_with_utc_timestamp(*args, **kwargs):
         return
 
     sep = kwargs.get("sep", " ")
+    if sep is None:
+        sep = " "
+    elif not isinstance(sep, str):
+        _ORIGINAL_PRINT(*args, **kwargs)
+        return
     text_args = [str(arg) for arg in args]
 
     # If each argument can become its own line (e.g., sep="\n"), prefix each one.
@@ -2244,7 +2249,7 @@ def _log_error_and_check_mei(error: Exception, context: str = "") -> bool:
     
     # Log to console (may not appear if stdout is captured)
     try:
-        print(f"\n[ERROR] {timestamp} - {context}", flush=True)
+        print(f"\n[ERROR] {context}", flush=True)
         print(f"[ERROR] Type: {error_type}", flush=True)
         print(f"[ERROR] Message: {error}", flush=True)
         sys.stdout.flush()

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2398,6 +2398,8 @@ async def global_exception_handler(request, exc):
 @app.middleware("http")
 async def disable_buffering(request, call_next):
     """Log every request once and ensure responses are not buffered."""
+    # Intentionally keep request-outcome logging enabled for all paths, including
+    # keepalive traffic, so tunnel liveliness/debugging has a single timeline.
     method = request.method
     path = request.url.path
     request_start = time.perf_counter()
@@ -3952,12 +3954,18 @@ async def post_fs_write(payload: Dict[str, Any]):
     """
     file_path = payload.get("path")
     content = payload.get("content")
-    mode = payload.get("mode", "write")
+    mode_raw = payload.get("mode", "write")
+    mode = mode_raw.strip().lower() if isinstance(mode_raw, str) else None
     
     if not file_path:
         raise HTTPException(status_code=400, detail="Missing 'path' field")
     if not content:
         raise HTTPException(status_code=400, detail="Missing 'content' field")
+    if mode not in ("write", "append"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid 'mode' value {mode_raw!r}; expected 'write' or 'append'",
+        )
     
     try:
         # Decode base64 content

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -42,6 +42,7 @@ import argparse
 import asyncio
 import base64
 import builtins
+import contextvars
 import json
 import math
 import os
@@ -88,7 +89,9 @@ from datetime import datetime, timezone
 _ISO_TIMESTAMP_PREFIX_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}T")
 _IS_WINDOWS = platform.system() == "Windows"
 _ORIGINAL_PRINT = builtins.print
-_PRINT_TIMESTAMP_STATE = threading.local()
+_PRINT_TIMESTAMP_SUPPRESS_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "_print_timestamp_suppress_depth", default=0
+)
 
 
 def _utc_now_iso() -> str:
@@ -135,23 +138,20 @@ def _prefix_log_text_with_utc_timestamps(text: str) -> str:
 @contextmanager
 def _suppress_print_timestamps():
     """Temporarily disable timestamp prefixing for system/UX output."""
-    previous_depth = int(getattr(_PRINT_TIMESTAMP_STATE, "suppress_depth", 0))
-    _PRINT_TIMESTAMP_STATE.suppress_depth = previous_depth + 1
+    token = _PRINT_TIMESTAMP_SUPPRESS_DEPTH.set(_PRINT_TIMESTAMP_SUPPRESS_DEPTH.get() + 1)
     try:
         yield
     finally:
-        if previous_depth <= 0:
-            try:
-                delattr(_PRINT_TIMESTAMP_STATE, "suppress_depth")
-            except Exception:
-                pass
-        else:
-            _PRINT_TIMESTAMP_STATE.suppress_depth = previous_depth
+        _PRINT_TIMESTAMP_SUPPRESS_DEPTH.reset(token)
 
 
 def _print_with_utc_timestamp(*args, **kwargs):
     """Global print wrapper that adds UTC timestamps to regular log lines."""
-    if int(getattr(_PRINT_TIMESTAMP_STATE, "suppress_depth", 0)) > 0:
+    if _PRINT_TIMESTAMP_SUPPRESS_DEPTH.get() > 0:
+        _ORIGINAL_PRINT(*args, **kwargs)
+        return
+
+    if kwargs.get("file") not in (None, sys.stdout):
         _ORIGINAL_PRINT(*args, **kwargs)
         return
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -4316,7 +4316,7 @@ def _get_max_restarts() -> Optional[int]:
     except (ValueError, TypeError):
         print(f"Warning: Invalid CYBERDRIVER_MAX_RESTARTS={raw_value!r}; ignoring restart limit")
         return None
-    if parsed < 0:
+    if parsed <= 0:
         return None
     return parsed
 
@@ -4357,7 +4357,7 @@ def _restart_cyberdriver_process() -> bool:
             f"Configured max restarts ({max_restarts}) exceeded "
             f"after {restart_count - 1} restart attempts."
         )
-        print("Set CYBERDRIVER_MAX_RESTARTS=-1 (or unset it) to allow unlimited retries.")
+        print("Set CYBERDRIVER_MAX_RESTARTS=0 (or any negative value, or unset it) to allow unlimited retries.")
         print(f"{'='*60}\n")
         sys.exit(1)
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -1981,14 +1981,15 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 
 # Post-type settle delay:
 # Remote desktops (Citrix/RDP/VDI) can render injected keystrokes slightly after
-# key events are queued. We wait 5ms per typed character (no base delay, no cap)
-# to reduce races with immediate follow-up actions/screenshots.
-TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.005)
+# key events are queued. We apply a fixed base delay plus a char-count-based
+# delay to reduce races with immediate follow-up actions/screenshots.
+TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
+TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
-    return max(0.0, char_count * TYPING_SETTLE_PER_CHAR_SECONDS)
+    return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
 
 
 async def _wait_for_typing_settle(text: str) -> None:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2200,6 +2200,11 @@ async def lifespan(app: FastAPI):
     # Startup
     app.state.start_time = time.time()
     _initialize_keyboard_type_state(app)
+    app.state.shutdown_requested = False
+    app.state.shutdown_task = None
+    # /internal/shutdown is intentionally tunnel-only; standalone server modes keep this unset.
+    if not hasattr(app.state, "tunnel_internal_token"):
+        app.state.tunnel_internal_token = None
     yield
     # Shutdown
     print("Shutting down...")
@@ -2209,7 +2214,6 @@ async def lifespan(app: FastAPI):
     print("Cleanup complete")
 
 app = FastAPI(title="Cyberdriver", version=VERSION, lifespan=lifespan)
-_initialize_keyboard_type_state(app)
 
 
 def _log_error_and_check_mei(error: Exception, context: str = "") -> bool:
@@ -2511,7 +2515,10 @@ async def post_shutdown(request: Request, payload: Optional[Dict[str, Any]] = No
             except Exception:
                 pass
             # Use a graceful interpreter exit so atexit handlers can flush buffered logs.
-            asyncio.get_running_loop().call_soon(sys.exit, 0)
+            loop = asyncio.get_running_loop()
+            loop.call_soon(sys.exit, 0)
+            # Fallback: force termination if SystemExit is intercepted by runtime wrappers.
+            loop.call_later(2.0, os._exit, 0)
 
         shutdown_task = asyncio.create_task(_delayed_shutdown())
         app.state.shutdown_task = shutdown_task

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2082,6 +2082,12 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 # delay to reduce races with immediate follow-up actions/screenshots.
 TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
 TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
+TYPING_SETTLE_LINEAR_THRESHOLD_CHARS = int(
+    _get_env_float("CYBERDRIVER_TYPING_SETTLE_LINEAR_THRESHOLD_CHARS", 300.0, minimum=0.0)
+)
+TYPING_SETTLE_LONG_TEXT_PER_CHAR_SECONDS = _get_env_float(
+    "CYBERDRIVER_TYPING_SETTLE_LONG_TEXT_PER_CHAR_SECONDS", 0.0008
+)
 KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE = _get_env_float(
     "CYBERDRIVER_KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE", 0.004
 )
@@ -2098,7 +2104,17 @@ KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS = _get_env_float(
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
-    return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
+    linear_threshold = max(0, int(TYPING_SETTLE_LINEAR_THRESHOLD_CHARS))
+    if char_count <= linear_threshold:
+        return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
+
+    overflow_chars = char_count - linear_threshold
+    return max(
+        0.0,
+        TYPING_SETTLE_BASE_SECONDS
+        + (linear_threshold * TYPING_SETTLE_PER_CHAR_SECONDS)
+        + (overflow_chars * TYPING_SETTLE_LONG_TEXT_PER_CHAR_SECONDS),
+    )
 
 
 def _hash_keyboard_type_text(text: str) -> str:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2202,11 +2202,19 @@ async def lifespan(app: FastAPI):
     _initialize_keyboard_type_state(app)
     app.state.shutdown_requested = False
     app.state.shutdown_task = None
+    app.state.shutdown_force_stop_handle = None
     # /internal/shutdown is intentionally tunnel-only; standalone server modes keep this unset.
     if not hasattr(app.state, "tunnel_internal_token"):
         app.state.tunnel_internal_token = None
     yield
     # Shutdown
+    force_stop_handle = getattr(app.state, "shutdown_force_stop_handle", None)
+    if force_stop_handle is not None:
+        try:
+            force_stop_handle.cancel()
+        except Exception:
+            pass
+        app.state.shutdown_force_stop_handle = None
     print("Shutting down...")
     
     # Shutdown the thread pool executor
@@ -2517,8 +2525,14 @@ async def post_shutdown(request: Request, payload: Optional[Dict[str, Any]] = No
             # Use a graceful interpreter exit so atexit handlers can flush buffered logs.
             loop = asyncio.get_running_loop()
             loop.call_soon(sys.exit, 0)
-            # Fallback: force termination if SystemExit is intercepted by runtime wrappers.
-            loop.call_later(2.0, os._exit, 0)
+            # Fallback: stop the loop if SystemExit gets intercepted by runtime wrappers.
+            # This still allows normal Python process teardown/atexit handling.
+            def _fallback_stop_loop():
+                try:
+                    loop.stop()
+                except Exception:
+                    pass
+            app.state.shutdown_force_stop_handle = loop.call_later(2.0, _fallback_stop_loop)
 
         shutdown_task = asyncio.create_task(_delayed_shutdown())
         app.state.shutdown_task = shutdown_task

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2312,6 +2312,53 @@ async def post_remote_keepalive_disable():
         return JSONResponse(status_code=500, content={"error": str(e)})
 
 
+@app.post("/shutdown")
+@app.post("/internal/shutdown")
+async def post_shutdown(payload: Optional[Dict[str, Any]] = None):
+    """Request cyberdriver to terminate itself.
+
+    Intended for cloud control-plane use when a machine/session is being turned off.
+    Returns immediately, then exits the process shortly after the response is sent.
+    """
+    try:
+        pid = os.getpid()
+        reason = None
+        source = "unknown"
+        if isinstance(payload, dict):
+            reason = payload.get("reason")
+            source = str(payload.get("source") or source)
+
+        if getattr(app.state, "shutdown_requested", False):
+            return {
+                "status": "already_shutting_down",
+                "pid": pid,
+                "reason": reason,
+                "source": source,
+            }
+
+        app.state.shutdown_requested = True
+        print(f"Shutdown requested via API (pid={pid}, source={source}, reason={reason or 'none'})")
+
+        async def _delayed_shutdown():
+            # Small delay gives HTTP response time to flush through tunnel/proxy.
+            await asyncio.sleep(0.25)
+            try:
+                _remove_pid_file_safely()
+            except Exception:
+                pass
+            os._exit(0)
+
+        asyncio.create_task(_delayed_shutdown())
+        return {
+            "status": "shutting_down",
+            "pid": pid,
+            "reason": reason,
+            "source": source,
+        }
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
 @app.get("/internal/diagnostics")
 async def get_diagnostics():
     """Get diagnostic information for debugging connection issues."""
@@ -3932,35 +3979,16 @@ def _restart_cyberdriver_process() -> bool:
     2. Spawns a new cyberdriver process with the exact same command-line arguments
     3. Exits the current process
     
-    Safety: After MAX_RESTARTS consecutive restarts without a successful long connection,
-    the process will exit rather than restart again to prevent infinite loops.
-    
     Returns:
         True if we're about to exit (new process spawned successfully)
         False if spawn failed and we should continue in current process
         
     Note: If successful, this function exits the process and never returns.
     """
-    MAX_RESTARTS = 5  # Maximum consecutive restarts before giving up
-    
     restart_count = _get_restart_count() + 1
-    
-    # Check if we've exceeded max restarts
-    if restart_count > MAX_RESTARTS:
-        print(f"\n{'='*60}")
-        print(f"❌ RESTART LIMIT REACHED")
-        print(f"{'='*60}")
-        print(f"\nCyberdriver has restarted {restart_count - 1} times without establishing")
-        print(f"a stable connection. This may indicate:")
-        print(f"   1. The Cyberdesk API is down for extended maintenance")
-        print(f"   2. Network connectivity issues")
-        print(f"   3. Persistent _MEI folder corruption (try reinstalling)")
-        print(f"\nTo restart manually, run: cyberdriver join --secret YOUR_KEY")
-        print(f"{'='*60}\n")
-        sys.exit(1)
-    
+
     print(f"\n{'='*60}")
-    print(f"🔄 RESTARTING CYBERDRIVER (attempt {restart_count}/{MAX_RESTARTS})")
+    print(f"🔄 RESTARTING CYBERDRIVER (attempt #{restart_count})")
     print(f"{'='*60}")
     print(f"Spawning fresh process to recover from potential _MEI issues...")
     print(f"This is equivalent to: cyberdriver stop && cyberdriver join ...")
@@ -3978,7 +4006,7 @@ def _restart_cyberdriver_process() -> bool:
     try:
         log_path = get_config_dir() / "restart-history.log"
         with open(log_path, "a", encoding="utf-8") as f:
-            f.write(f"\n[{_utc_now_iso()}] Restarting cyberdriver (attempt {restart_count}/{MAX_RESTARTS})\n")
+            f.write(f"\n[{_utc_now_iso()}] Restarting cyberdriver (attempt #{restart_count})\n")
             f.write(f"Command: {' '.join(cmd)}\n")
             f.write(f"PID (old): {os.getpid()}\n")
             f.write(f"_MEIPASS: {getattr(sys, '_MEIPASS', 'N/A')}\n")

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -5650,6 +5650,13 @@ async def run_join(host: str, port: int, secret: str, target_port: int, keepaliv
                    black_screen_check_interval: float = 30.0,
                    debug_enabled: bool = False):
     """Run both API server and tunnel client."""
+    # Ensure default transfer directory exists for file operations during join.
+    transfers_dir = pathlib.Path.home() / "CyberdeskTransfers"
+    try:
+        transfers_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        print(f"Warning: Failed to create transfer directory at {transfers_dir}: {e}")
+
     # Store connection info for use by update endpoint
     _set_connection_info(host, port)
     # Per-process marker used to gate tunnel-only internal endpoints.

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3549,11 +3549,9 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
             # tunnel I/O on the main event loop. We still await completion,
             # so the endpoint only returns after typing is actually done.
             if _IS_WINDOWS:
-                try:
-                    await asyncio.to_thread(_type_with_win32_sendinput, text)
-                except Exception as e:
-                    print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
-                    await asyncio.to_thread(pyautogui.typewrite, text)
+                # Avoid fallback retyping the whole string after a partial
+                # SendInput failure, which can duplicate already-queued chars.
+                await asyncio.to_thread(_type_with_win32_sendinput, text)
             else:
                 await asyncio.to_thread(pyautogui.typewrite, text)
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -1981,18 +1981,14 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 
 # Post-type settle delay:
 # Remote desktops (Citrix/RDP/VDI) can render injected keystrokes slightly after
-# key events are queued. A short char-count-based wait reduces races with immediate
-# follow-up actions/screenshots.
-TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
-TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
-TYPING_SETTLE_MAX_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS", 1.2)
+# key events are queued. We wait 5ms per typed character (no base delay, no cap)
+# to reduce races with immediate follow-up actions/screenshots.
+TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.005)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
-    uncapped = TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS)
-    max_delay = max(TYPING_SETTLE_MAX_SECONDS, TYPING_SETTLE_BASE_SECONDS)
-    return max(0.0, min(uncapped, max_delay))
+    return max(0.0, char_count * TYPING_SETTLE_PER_CHAR_SECONDS)
 
 
 async def _wait_for_typing_settle(text: str) -> None:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -64,7 +64,7 @@ from typing import Dict, List, Optional, Tuple, Union, Any
 from enum import Enum
 from dataclasses import dataclass
 from io import BytesIO
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 
 import certifi
 import httpx
@@ -87,6 +87,7 @@ from datetime import datetime, timezone
 
 _ISO_TIMESTAMP_PREFIX_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}T")
 _ORIGINAL_PRINT = builtins.print
+_PRINT_TIMESTAMP_STATE = threading.local()
 
 
 def _utc_now_iso() -> str:
@@ -115,8 +116,29 @@ def _prefix_log_line_with_utc_timestamp(text: str) -> str:
     return f"{prefix}[{_utc_now_iso()}] {body}"
 
 
+@contextmanager
+def _suppress_print_timestamps():
+    """Temporarily disable timestamp prefixing for system/UX output."""
+    previous_depth = int(getattr(_PRINT_TIMESTAMP_STATE, "suppress_depth", 0))
+    _PRINT_TIMESTAMP_STATE.suppress_depth = previous_depth + 1
+    try:
+        yield
+    finally:
+        if previous_depth <= 0:
+            try:
+                delattr(_PRINT_TIMESTAMP_STATE, "suppress_depth")
+            except Exception:
+                pass
+        else:
+            _PRINT_TIMESTAMP_STATE.suppress_depth = previous_depth
+
+
 def _print_with_utc_timestamp(*args, **kwargs):
     """Global print wrapper that adds UTC timestamps to regular log lines."""
+    if int(getattr(_PRINT_TIMESTAMP_STATE, "suppress_depth", 0)) > 0:
+        _ORIGINAL_PRINT(*args, **kwargs)
+        return
+
     end = kwargs.get("end", "\n")
     # Preserve non-line-buffered prints used by countdown/progress output.
     if end != "\n":
@@ -6146,7 +6168,8 @@ def main():
     
     # Print banner if no arguments or help requested
     if len(sys.argv) == 1 or (len(sys.argv) == 2 and sys.argv[1] in ['-h', '--help']):
-        print_banner()
+        with _suppress_print_timestamps():
+            print_banner()
     
     parser = argparse.ArgumentParser(
         description="Remote computer control via Cyberdesk",
@@ -6274,7 +6297,8 @@ def main():
     # Handle help or no command
     if not args.command or args.help:
         if not (len(sys.argv) == 1 or (len(sys.argv) == 2 and sys.argv[1] in ['-h', '--help'])):
-            print_banner()
+            with _suppress_print_timestamps():
+                print_banner()
         print("Commands:")
         print("  join --secret KEY                         Connect to Cyberdesk Cloud")
         print("  join --secret KEY --keepalive             Enable keepalive")
@@ -6318,7 +6342,8 @@ def main():
             old_argv = info.get("argv", [])
             timestamp = _utc_now_iso()
             
-            print_banner(mode="connecting")
+            with _suppress_print_timestamps():
+                print_banner(mode="connecting")
             # Use yellow/warning color for visibility (if terminal supports it)
             if _should_use_color():
                 print(f"\033[93mCyberdriver is already running (PID {old_pid}).\033[0m")
@@ -6399,13 +6424,14 @@ def main():
             child_argv.append(f"--_stdio-log={stdio_log_path}")
 
             # Show the nice banner in the *current* terminal (this is not the detached child).
-            print_banner(mode="connecting")
-            print("Cyberdriver is now running in the background.")
-            print("You can close PowerShell.")
-            print(f"Logs: {stdio_log_path}")
-            _print_prominent_stop_hint()
-            print("(You can also end cyberdriver.exe in Task Manager.)")
-            print()
+            with _suppress_print_timestamps():
+                print_banner(mode="connecting")
+                print("Cyberdriver is now running in the background.")
+                print("You can close PowerShell.")
+                print(f"Logs: {stdio_log_path}")
+                _print_prominent_stop_hint()
+                print("(You can also end cyberdriver.exe in Task Manager.)")
+                print()
             _windows_relaunch_detached(child_argv, stdio_log_path)
 
             # Default UX: return immediately. If the user wants logs in this terminal,
@@ -6424,7 +6450,8 @@ def main():
     
     # Show banner for join command
     if args.command == "join":
-        print_banner(mode="connecting")
+        with _suppress_print_timestamps():
+            print_banner(mode="connecting")
     
     # Check for admin privileges if black screen recovery or persistent display is enabled
     needs_admin = False

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -186,7 +186,7 @@ def _print_with_utc_timestamp(*args, **kwargs):
     _ORIGINAL_PRINT(_prefix_log_text_with_utc_timestamps(rendered), **kwargs_single)
 
 
-if getattr(builtins.print, "__name__", "") != "_print_with_utc_timestamp":
+if builtins.print is not _print_with_utc_timestamp:
     builtins.print = _print_with_utc_timestamp
 
 # -----------------------------------------------------------------------------
@@ -5083,8 +5083,10 @@ class TunnelClient:
             try:
                 payload = json.loads(body.decode('utf-8'))
                 text = payload.get("text")
-                if isinstance(text, str):
-                    request_timeout = _estimate_keyboard_type_timeout_seconds(text)
+                if text is not None:
+                    text_for_timeout = text if isinstance(text, str) else str(text)
+                    normalized_for_timeout = _normalize_text_for_keyboard_typing(text_for_timeout)
+                    request_timeout = _estimate_keyboard_type_timeout_seconds(normalized_for_timeout)
                     use_custom_timeout = True
             except Exception:
                 pass  # Fall back to default client if parsing fails

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3928,12 +3928,13 @@ async def post_fs_write(payload: Dict[str, Any]):
         raise HTTPException(status_code=400, detail=f"Invalid base64 content: {e}")
     
     try:
-        # Resolve path - no restrictions
-        safe_path = pathlib.Path(file_path).expanduser().resolve()
-        
-        # If path doesn't specify a directory, default to CyberdeskTransfers
-        if not safe_path.parent.exists() and str(safe_path.parent) == ".":
-            safe_path = pathlib.Path.home() / "CyberdeskTransfers" / safe_path.name
+        # If path doesn't specify a directory, default to CyberdeskTransfers.
+        raw_path = pathlib.Path(file_path).expanduser()
+        if (not raw_path.is_absolute()) and str(raw_path.parent) in ("", "."):
+            safe_path = (pathlib.Path.home() / "CyberdeskTransfers" / raw_path.name).resolve()
+        else:
+            # Resolve path - no restrictions
+            safe_path = raw_path.resolve()
         
         # Create parent directories if they don't exist
         safe_path.parent.mkdir(parents=True, exist_ok=True)

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -5219,7 +5219,6 @@ class TunnelClient:
             debug_logger.error("REQUEST", f"Request failed: {error_msg}", method=method, path=path, duration_ms=f"{duration_ms:.1f}ms")
             
             # Log to console with full details
-            timestamp = _utc_now_iso()
             print(f"\n{'='*60}", flush=True)
             print(f"[TUNNEL FORWARD ERROR]", flush=True)
             print(f"Error type: {error_type}", flush=True)
@@ -5233,7 +5232,7 @@ class TunnelClient:
             try:
                 log_path = get_config_dir() / "tunnel-forward-errors.log"
                 with open(log_path, "a", encoding="utf-8") as f:
-                    f.write(f"\n[{timestamp}] TUNNEL FORWARD ERROR\n")
+                    f.write(f"\n[{_utc_now_iso()}] TUNNEL FORWARD ERROR\n")
                     f.write(f"Type: {error_type}\n")
                     f.write(f"Message: {error_msg}\n")
                     f.write(f"Method: {method}\n")

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3527,7 +3527,7 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
 
     typing_lock: asyncio.Lock = app.state.keyboard_type_lock
 
-    now = time.time()
+    now = time.monotonic()
     inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
     inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
     if (
@@ -3540,7 +3540,7 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
         return {}
 
     async with typing_lock:
-        now = time.time()
+        now = time.monotonic()
         # Re-check in-flight state after acquiring the lock to avoid a race where
         # two identical requests pass the pre-lock check simultaneously.
         inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
@@ -3613,13 +3613,13 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
                     # post-completion dedupe state before re-raising cancellation.
                     if dedupe_key:
                         app.state.keyboard_type_last_hash = dedupe_key
-                        app.state.keyboard_type_last_completed_at = time.time()
+                        app.state.keyboard_type_last_completed_at = time.monotonic()
                 raise
 
             await _wait_for_typing_settle(text)
             if dedupe_key:
                 app.state.keyboard_type_last_hash = dedupe_key
-                app.state.keyboard_type_last_completed_at = time.time()
+                app.state.keyboard_type_last_completed_at = time.monotonic()
         finally:
             app.state.keyboard_type_inflight_hash = None
             app.state.keyboard_type_inflight_started_at = 0.0

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2213,6 +2213,17 @@ async def lifespan(app: FastAPI):
         app.state.tunnel_internal_token = None
     yield
     # Shutdown
+    shutdown_task_ref = getattr(app.state, "shutdown_task", None)
+    if isinstance(shutdown_task_ref, asyncio.Task) and not shutdown_task_ref.done():
+        shutdown_task_ref.cancel()
+        try:
+            await shutdown_task_ref
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+    app.state.shutdown_task = None
+
     force_stop_handle = getattr(app.state, "shutdown_force_stop_handle", None)
     if force_stop_handle is not None:
         try:
@@ -2545,7 +2556,9 @@ async def post_shutdown(request: Request):
             # Fallback: retry graceful exit. If that is intercepted again, force terminate.
             def _fallback_exit_process():
                 try:
-                    loop.call_later(2.0, os._exit, 0)
+                    inner_handle = loop.call_later(2.0, os._exit, 0)
+                    # Track the final-resort handle so lifespan shutdown can cancel it.
+                    app.state.shutdown_force_stop_handle = inner_handle
                 except Exception:
                     os._exit(0)
                 sys.exit(0)

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -4685,11 +4685,12 @@ class TunnelClient:
                     close_code=close_code
                 )
                 
-                # Only reset failure counter if connection lasted more than 10 seconds
-                # Short-lived connections indicate an ongoing problem
+                # After a stable connection, reset all retry/backoff state.
+                # Short-lived connections indicate an ongoing problem.
                 if connection_duration > 10:
                     self._consecutive_failures = 0
                     failures_at_max_sleep = 0
+                    sleep_time = self.min_sleep
                     # Reset restart count since we had a successful long connection
                     # This clears the CYBERDRIVER_RESTART_COUNT env var
                     if "CYBERDRIVER_RESTART_COUNT" in os.environ:
@@ -4839,6 +4840,7 @@ class TunnelClient:
                 if connection_duration > 10:
                     self._consecutive_failures = 0
                     failures_at_max_sleep = 0
+                    sleep_time = self.min_sleep
                     # Reset restart count since we had a successful long connection
                     if "CYBERDRIVER_RESTART_COUNT" in os.environ:
                         del os.environ["CYBERDRIVER_RESTART_COUNT"]

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2100,6 +2100,26 @@ KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS = _get_env_float(
 KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS = _get_env_float(
     "CYBERDRIVER_KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS", 300.0, minimum=1.0
 )
+WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS = _get_env_float(
+    "CYBERDRIVER_WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS", 0.0015
+)
+WINDOWS_SENDINPUT_DELAY_THRESHOLD_CHARS = int(
+    _get_env_float("CYBERDRIVER_WINDOWS_SENDINPUT_DELAY_THRESHOLD_CHARS", 120.0, minimum=0.0)
+)
+
+UNICODE_TYPING_REPLACEMENTS = (
+    ("\r\n", "\n"),
+    ("\r", "\n"),
+    ("\u00A0", " "),   # non-breaking space
+    ("\u2013", "-"),   # en dash
+    ("\u2014", "-"),   # em dash
+    ("\u2212", "-"),   # unicode minus
+    ("\u2018", "'"),   # left single quote
+    ("\u2019", "'"),   # right single quote
+    ("\u201C", '"'),   # left double quote
+    ("\u201D", '"'),   # right double quote
+    ("\u2026", "..."), # ellipsis
+)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
@@ -2119,6 +2139,13 @@ def _compute_typing_settle_delay(text: str) -> float:
 
 def _hash_keyboard_type_text(text: str) -> str:
     return hashlib.sha256((text or "").encode("utf-8", errors="replace")).hexdigest()
+
+
+def _normalize_text_for_keyboard_typing(text: str) -> str:
+    normalized = text or ""
+    for source, target in UNICODE_TYPING_REPLACEMENTS:
+        normalized = normalized.replace(source, target)
+    return normalized
 
 
 def _estimate_keyboard_type_timeout_seconds(text: str) -> float:
@@ -3300,6 +3327,9 @@ def _type_with_win32_sendinput(text: str):
     """Type text using Windows SendInput API with hardware scan codes."""
     LSHIFT_SCANCODE = 0x2A
     unsupported_chars: Dict[str, int] = {}
+    inter_key_delay = 0.0
+    if len(text or "") >= max(0, WINDOWS_SENDINPUT_DELAY_THRESHOLD_CHARS):
+        inter_key_delay = max(0.0, WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS)
     
     for char in text:
         # Handle space specially when experimental mode is enabled
@@ -3338,6 +3368,8 @@ def _type_with_win32_sendinput(text: str):
         _win32_send_key(scan_code, key_up=True)
         if needs_shift:
             _win32_send_key(LSHIFT_SCANCODE, key_up=True)
+        if inter_key_delay > 0:
+            time.sleep(inter_key_delay)
 
     if unsupported_chars:
         total_unsupported = sum(unsupported_chars.values())
@@ -3389,6 +3421,7 @@ async def post_keyboard_type(payload: Dict[str, str]):
     if not isinstance(text, str):
         text = str(text)
 
+    text = _normalize_text_for_keyboard_typing(text)
     text_hash = _hash_keyboard_type_text(text)
     estimated_timeout_seconds = _estimate_keyboard_type_timeout_seconds(text)
     dedupe_window_seconds = max(

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2325,45 +2325,18 @@ async def post_remote_keepalive_disable():
         return JSONResponse(status_code=500, content={"error": str(e)})
 
 
-def _extract_bearer_token(value: Optional[str]) -> Optional[str]:
-    if not value:
-        return None
-    parts = value.split(" ", 1)
-    if len(parts) != 2:
-        return None
-    scheme, token = parts[0].strip().lower(), parts[1].strip()
-    if scheme != "bearer" or not token:
-        return None
-    return token
+TUNNEL_INTERNAL_REQUEST_HEADER = "x-cyberdesk-tunnel-token"
 
 
-def _get_shutdown_auth_token() -> Optional[str]:
-    """Resolve shutdown auth token from env or runtime state."""
-    env_token = os.environ.get("CYBERDRIVER_SHUTDOWN_TOKEN")
-    if env_token:
-        return env_token
-    state_token = getattr(app.state, "shutdown_token", None)
-    if isinstance(state_token, str) and state_token:
-        return state_token
-    return None
-
-
-def _get_shutdown_request_token(request: Request, payload: Optional[Dict[str, Any]]) -> Optional[str]:
-    """Extract shutdown token from Authorization/header/body."""
-    token = _extract_bearer_token(request.headers.get("authorization"))
-    if token:
-        return token
-
-    header_token = request.headers.get("x-cyberdriver-shutdown-token")
-    if header_token:
-        return header_token.strip()
-
-    if isinstance(payload, dict):
-        payload_token = payload.get("token")
-        if payload_token is not None:
-            return str(payload_token).strip()
-
-    return None
+def _is_request_from_active_tunnel(request: Request) -> bool:
+    """Return True if request carries the active in-process tunnel marker."""
+    expected = getattr(app.state, "tunnel_internal_token", None)
+    if not isinstance(expected, str) or not expected:
+        return False
+    provided = request.headers.get(TUNNEL_INTERNAL_REQUEST_HEADER)
+    if not provided:
+        return False
+    return secrets.compare_digest(provided, expected)
 
 
 @app.post("/internal/shutdown")
@@ -2374,13 +2347,8 @@ async def post_shutdown(request: Request, payload: Optional[Dict[str, Any]] = No
     Returns immediately, then exits the process shortly after the response is sent.
     """
     try:
-        expected_token = _get_shutdown_auth_token()
-        if not expected_token:
-            raise HTTPException(status_code=503, detail="Shutdown token is not configured")
-
-        provided_token = _get_shutdown_request_token(request, payload)
-        if not provided_token or not secrets.compare_digest(provided_token, expected_token):
-            raise HTTPException(status_code=401, detail="Unauthorized")
+        if not _is_request_from_active_tunnel(request):
+            raise HTTPException(status_code=403, detail="Forbidden: tunnel-only endpoint")
 
         pid = os.getpid()
         reason = None
@@ -4285,7 +4253,7 @@ class TunnelClient:
     IDEMPOTENCY_CACHE_TTL = 60.0  # Seconds to keep cached responses
     IDEMPOTENCY_CACHE_MAX_SIZE = 1000  # Maximum number of cached responses
     
-    def __init__(self, host: str, port: int, secret: str, target_port: int, config: Config, keepalive_manager: Optional["KeepAliveManager"] = None, remote_keepalive_for_main_id: Optional[str] = None):
+    def __init__(self, host: str, port: int, secret: str, target_port: int, config: Config, keepalive_manager: Optional["KeepAliveManager"] = None, remote_keepalive_for_main_id: Optional[str] = None, internal_request_token: Optional[str] = None):
         self.host = host
         self.port = port
         self.secret = secret
@@ -4297,6 +4265,7 @@ class TunnelClient:
         self._consecutive_failures = 0  # Track consecutive short-lived connections for diagnostics
         self.keepalive_manager = keepalive_manager
         self.remote_keepalive_for_main_id = remote_keepalive_for_main_id
+        self.internal_request_token = internal_request_token
         
         # Idempotency cache: key -> (timestamp, response)
         # Used to prevent duplicate execution of actions when retries occur
@@ -4797,6 +4766,9 @@ class TunnelClient:
         path = meta["path"]
         query = meta.get("query", "")
         headers = meta.get("headers", {})
+        request_headers = dict(headers) if isinstance(headers, dict) else {}
+        if self.internal_request_token:
+            request_headers[TUNNEL_INTERNAL_REQUEST_HEADER] = self.internal_request_token
         
         # Check for idempotency key (case-insensitive header lookup)
         idempotency_key: Optional[str] = None
@@ -4855,7 +4827,7 @@ class TunnelClient:
                     pool=30.0
                 )
                 async with httpx.AsyncClient(timeout=timeout_obj) as request_client:
-                    async with request_client.stream(method, url, headers=headers, content=body) as response:
+                    async with request_client.stream(method, url, headers=request_headers, content=body) as response:
                         duration_ms = (time.time() - request_start) * 1000
                         print(f"{method} {path} -> {response.status_code}")
                         debug_logger.request_forwarded(method, path, response.status_code, duration_ms)
@@ -4872,7 +4844,7 @@ class TunnelClient:
                         }
             else:
                 # Use default client for all other requests (30s timeout) 
-                async with client.stream(method, url, headers=headers, content=body) as response:
+                async with client.stream(method, url, headers=request_headers, content=body) as response:
                     duration_ms = (time.time() - request_start) * 1000
                     print(f"{method} {path} -> {response.status_code}")
                     debug_logger.request_forwarded(method, path, response.status_code, duration_ms)
@@ -5475,8 +5447,9 @@ async def run_join(host: str, port: int, secret: str, target_port: int, keepaliv
     """Run both API server and tunnel client."""
     # Store connection info for use by update endpoint
     _set_connection_info(host, port)
-    # Use join secret as default auth token for /internal/shutdown.
-    app.state.shutdown_token = secret
+    # Per-process marker used to gate tunnel-only internal endpoints.
+    tunnel_internal_token = secrets.token_hex(32)
+    app.state.tunnel_internal_token = tunnel_internal_token
     
     config = get_config()
     
@@ -5575,7 +5548,8 @@ async def run_join(host: str, port: int, secret: str, target_port: int, keepaliv
         return TunnelClient(
             host, port, secret, actual_target_port, config,
             keepalive_manager=keepalive_manager if keepalive_enabled else None,
-            remote_keepalive_for_main_id=register_as_keepalive_for
+            remote_keepalive_for_main_id=register_as_keepalive_for,
+            internal_request_token=tunnel_internal_token,
         )
 
     async def start_tunnel():

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2347,8 +2347,17 @@ async def global_exception_handler(request, exc):
 
 @app.middleware("http")
 async def disable_buffering(request, call_next):
-    """Middleware to ensure responses are not buffered."""
-    response = await call_next(request)
+    """Log every request once and ensure responses are not buffered."""
+    method = request.method
+    path = request.url.path
+    try:
+        response = await call_next(request)
+    except Exception:
+        # Keep one request outcome line even when downstream raises unexpectedly.
+        print(f"{method} {path} -> 500")
+        raise
+
+    print(f"{method} {path} -> {response.status_code}")
     # Add headers to disable any proxy buffering
     response.headers["X-Accel-Buffering"] = "no"
     response.headers["Cache-Control"] = "no-cache"
@@ -5022,7 +5031,6 @@ class TunnelClient:
                 async with httpx.AsyncClient(timeout=timeout_obj) as request_client:
                     async with request_client.stream(method, url, headers=request_headers, content=body) as response:
                         duration_ms = (time.time() - request_start) * 1000
-                        print(f"{method} {path} -> {response.status_code}")
                         debug_logger.request_forwarded(method, path, response.status_code, duration_ms)
                         
                         # Read the response body immediately to avoid buffering
@@ -5039,7 +5047,6 @@ class TunnelClient:
                 # Use default client for all other requests (30s timeout) 
                 async with client.stream(method, url, headers=request_headers, content=body) as response:
                     duration_ms = (time.time() - request_start) * 1000
-                    print(f"{method} {path} -> {response.status_code}")
                     debug_logger.request_forwarded(method, path, response.status_code, duration_ms)
                     
                     # Read the response body immediately to avoid buffering

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3604,6 +3604,9 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
                 await asyncio.shield(typing_task)
             except asyncio.CancelledError:
                 try:
+                    # Intentional trade-off: waiting here keeps dedupe state
+                    # consistent, but holds typing_lock until typing finishes.
+                    # Queued /keyboard/type requests can stall during this window.
                     await typing_task
                 except Exception:
                     pass
@@ -6622,20 +6625,20 @@ def main():
 
     # Handle help or no command
     if not args.command or args.help:
-        if not (len(sys.argv) == 1 or (len(sys.argv) == 2 and sys.argv[1] in ['-h', '--help'])):
-            with _suppress_print_timestamps():
+        with _suppress_print_timestamps():
+            if not (len(sys.argv) == 1 or (len(sys.argv) == 2 and sys.argv[1] in ['-h', '--help'])):
                 print_banner()
-        print("Commands:")
-        print("  join --secret KEY                         Connect to Cyberdesk Cloud")
-        print("  join --secret KEY --keepalive             Enable keepalive")
-        print("  join --secret KEY --black-screen-recovery Enable black screen detection (Windows)")
-        print("  join --secret KEY --add-persistent-display Install virtual display driver (Windows)")
-        print("  join --secret KEY --debug                 Enable debug logging to ~/.cyberdriver/logs/")
-        print("  coords                                    Capture screen coordinates (for keepalive)")
-        print("  stop                                     Stop running Cyberdriver")
-        print("  logs                                     Tail Cyberdriver logs (realtime)")
-        print()
-        print("For more info: cyberdriver join -h")
+            print("Commands:")
+            print("  join --secret KEY                         Connect to Cyberdesk Cloud")
+            print("  join --secret KEY --keepalive             Enable keepalive")
+            print("  join --secret KEY --black-screen-recovery Enable black screen detection (Windows)")
+            print("  join --secret KEY --add-persistent-display Install virtual display driver (Windows)")
+            print("  join --secret KEY --debug                 Enable debug logging to ~/.cyberdriver/logs/")
+            print("  coords                                    Capture screen coordinates (for keepalive)")
+            print("  stop                                     Stop running Cyberdriver")
+            print("  logs                                     Tail Cyberdriver logs (realtime)")
+            print()
+            print("For more info: cyberdriver join -h")
         sys.exit(0)
 
     if args.command == "stop":

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2079,13 +2079,20 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 # Remote desktops (Citrix/RDP/VDI) can render injected keystrokes slightly after
 # key events are queued. We apply a fixed base delay plus a char-count-based
 # delay to reduce races with immediate follow-up actions/screenshots.
+# To prevent upstream request timeouts from causing duplicate retry typing,
+# this delay is capped by default. Set CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS=0
+# to disable the cap and use purely uncapped linear delay.
 TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
 TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
+TYPING_SETTLE_MAX_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_MAX_SECONDS", 1.5)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
-    return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
+    uncapped_delay = TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS)
+    if TYPING_SETTLE_MAX_SECONDS <= 0:
+        return max(0.0, uncapped_delay)
+    return max(0.0, min(uncapped_delay, TYPING_SETTLE_MAX_SECONDS))
 
 
 async def _wait_for_typing_settle(text: str) -> None:
@@ -3254,6 +3261,7 @@ def _win32_send_key(scan_code: int, key_up: bool = False):
 def _type_with_win32_sendinput(text: str):
     """Type text using Windows SendInput API with hardware scan codes."""
     LSHIFT_SCANCODE = 0x2A
+    unsupported_chars: Dict[str, int] = {}
     
     for char in text:
         # Handle space specially when experimental mode is enabled
@@ -3282,7 +3290,7 @@ def _type_with_win32_sendinput(text: str):
             scan_code = SYMBOL_SCANCODES[char]
         
         if scan_code is None:
-            print(f"Warning: Character '{char}' not supported by scan code method, skipping")
+            unsupported_chars[char] = unsupported_chars.get(char, 0) + 1
             continue
         
         # Send key events
@@ -3292,6 +3300,17 @@ def _type_with_win32_sendinput(text: str):
         _win32_send_key(scan_code, key_up=True)
         if needs_shift:
             _win32_send_key(LSHIFT_SCANCODE, key_up=True)
+
+    if unsupported_chars:
+        total_unsupported = sum(unsupported_chars.values())
+        top_items = sorted(unsupported_chars.items(), key=lambda item: item[1], reverse=True)[:5]
+        summary = ", ".join(f"{repr(ch)} x{count}" for ch, count in top_items)
+        remaining = len(unsupported_chars) - len(top_items)
+        extra = f" (+{remaining} more)" if remaining > 0 else ""
+        print(
+            f"Warning: Skipped {total_unsupported} unsupported character(s) "
+            f"in scan code typing: {summary}{extra}"
+        )
 
 
 def _press_key_with_scancode(key: str, key_up: bool = False):

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -42,6 +42,7 @@ import argparse
 import asyncio
 import base64
 import json
+import math
 import os
 import platform
 import pathlib
@@ -1379,7 +1380,7 @@ async def connect_with_headers(uri, headers_dict):
 CONFIG_DIR = ".cyberdriver"
 CONFIG_FILE = "config.json"
 PID_FILE = "cyberdriver.pid.json"
-VERSION = "0.0.39"
+VERSION = "0.0.40"
 
 @dataclass
 class Config:
@@ -1975,6 +1976,9 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
         value = float(raw)
     except ValueError:
         print(f"Warning: invalid {name}={raw!r}; using default {default}")
+        return default
+    if not math.isfinite(value):
+        print(f"Warning: non-finite {name}={raw!r}; using default {default}")
         return default
     return max(minimum, value)
 

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2047,7 +2047,10 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
     if not math.isfinite(value):
         print(f"Warning: non-finite {name}={raw!r}; using default {default}")
         return default
-    return max(minimum, value)
+    if value < minimum:
+        print(f"Warning: {name}={raw!r} is below minimum {minimum}; clamping to {minimum}")
+        return minimum
+    return value
 
 
 # Post-type settle delay:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3431,7 +3431,7 @@ def _press_key_with_scancode(key: str, key_up: bool = False):
 
 
 @app.post("/computer/input/keyboard/type")
-async def post_keyboard_type(request: Request, payload: Dict[str, str]):
+async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
     """Type a string of text."""
     text = payload.get("text")
     if not text:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -87,6 +87,7 @@ from datetime import datetime, timezone
 # -----------------------------------------------------------------------------
 
 _ISO_TIMESTAMP_PREFIX_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}T")
+_IS_WINDOWS = platform.system() == "Windows"
 _ORIGINAL_PRINT = builtins.print
 _PRINT_TIMESTAMP_STATE = threading.local()
 
@@ -2157,7 +2158,7 @@ def _estimate_keyboard_type_timeout_seconds(text: str) -> float:
     # Windows long-text typing may include per-key pacing in SendInput mode.
     # Include that extra time so timeout/dedupe windows track actual duration.
     if (
-        platform.system() == "Windows"
+        _IS_WINDOWS
         and char_count >= WINDOWS_SENDINPUT_DELAY_THRESHOLD_CHARS
         and WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS > 0
     ):
@@ -3340,7 +3341,7 @@ def _type_with_win32_sendinput(text: str):
     unsupported_chars: Dict[str, int] = {}
     inter_key_delay = 0.0
     if len(text or "") >= WINDOWS_SENDINPUT_DELAY_THRESHOLD_CHARS:
-        inter_key_delay = max(0.0, WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS)
+        inter_key_delay = WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS
     
     for char in text:
         # Handle space specially when experimental mode is enabled
@@ -3502,7 +3503,7 @@ async def post_keyboard_type(request: Request, payload: Dict[str, str]):
             # Execute typing in a worker thread so long input doesn't block
             # tunnel I/O on the main event loop. We still await completion,
             # so the endpoint only returns after typing is actually done.
-            if platform.system() == "Windows":
+            if _IS_WINDOWS:
                 try:
                     await asyncio.to_thread(_type_with_win32_sendinput, text)
                 except Exception as e:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -4182,7 +4182,7 @@ async def post_powershell_exec(payload: Dict[str, Any]):
         
         # Log to console
         print(f"\n{'='*60}", flush=True)
-        print(f"[POWERSHELL EXEC ERROR] {timestamp}", flush=True)
+        print(f"[POWERSHELL EXEC ERROR]", flush=True)
         print(f"Error type: {error_type}", flush=True)
         print(f"Error message: {error_msg}", flush=True)
         print(f"Command: {command[:100]}..." if len(command) > 100 else f"Command: {command}", flush=True)
@@ -6258,7 +6258,7 @@ def check_mei_health(context: str = "") -> bool:
         
         # Print to console
         print(f"\n{'='*70}")
-        print(f"[CRITICAL] _MEI HEALTH CHECK FAILED at {timestamp}")
+        print(f"[CRITICAL] _MEI HEALTH CHECK FAILED")
         print(f"[CRITICAL] Context: {context}")
         print(f"[CRITICAL] _MEIPASS: {meipass}")
         print(f"[CRITICAL] Missing directories: {missing}")

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2095,7 +2095,7 @@ KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS = _get_env_float(
     "CYBERDRIVER_KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS", 8.0
 )
 KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS = _get_env_float(
-    "CYBERDRIVER_KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS", 5.0
+    "CYBERDRIVER_KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS", 20.0
 )
 KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS = _get_env_float(
     "CYBERDRIVER_KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS", 300.0, minimum=1.0
@@ -3390,6 +3390,11 @@ async def post_keyboard_type(payload: Dict[str, str]):
         text = str(text)
 
     text_hash = _hash_keyboard_type_text(text)
+    estimated_timeout_seconds = _estimate_keyboard_type_timeout_seconds(text)
+    dedupe_window_seconds = max(
+        KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS,
+        min(120.0, estimated_timeout_seconds + 5.0),
+    )
 
     typing_lock: Optional[asyncio.Lock] = getattr(app.state, "keyboard_type_lock", None)
     if typing_lock is None:
@@ -3426,7 +3431,7 @@ async def post_keyboard_type(payload: Dict[str, str]):
         if (
             isinstance(last_hash, str)
             and last_hash == text_hash
-            and (now - last_completed) <= KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS
+            and (now - last_completed) <= dedupe_window_seconds
         ):
             print("Duplicate /keyboard/type payload received shortly after completion; skipping retry typing")
             return {}

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2542,14 +2542,14 @@ async def post_shutdown(request: Request):
             # Use a graceful interpreter exit so atexit handlers can flush buffered logs.
             loop = asyncio.get_running_loop()
             loop.call_soon(sys.exit, 0)
-            # Fallback: stop the loop if SystemExit gets intercepted by runtime wrappers.
-            # This still allows normal Python process teardown/atexit handling.
-            def _fallback_stop_loop():
+            # Fallback: retry graceful exit. If that is intercepted again, force terminate.
+            def _fallback_exit_process():
                 try:
-                    loop.stop()
+                    loop.call_later(2.0, os._exit, 0)
                 except Exception:
-                    pass
-            app.state.shutdown_force_stop_handle = loop.call_later(2.0, _fallback_stop_loop)
+                    os._exit(0)
+                sys.exit(0)
+            app.state.shutdown_force_stop_handle = loop.call_later(2.0, _fallback_exit_process)
 
         shutdown_task = asyncio.create_task(_delayed_shutdown())
         app.state.shutdown_task = shutdown_task
@@ -3565,7 +3565,7 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
             if _IS_WINDOWS:
                 # Avoid fallback retyping the whole string after a partial
                 # SendInput failure, which can duplicate already-queued chars.
-                await asyncio.to_thread(_type_with_win32_sendinput, text)
+                typing_task = asyncio.create_task(asyncio.to_thread(_type_with_win32_sendinput, text))
             else:
                 non_ascii_chars: Dict[str, int] = {}
                 for ch in text:
@@ -3581,7 +3581,18 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
                         f"Warning: pyautogui.typewrite may skip {skipped_count} non-ASCII character(s): "
                         f"{summary}{extra}"
                     )
-                await asyncio.to_thread(pyautogui.typewrite, text)
+                typing_task = asyncio.create_task(asyncio.to_thread(pyautogui.typewrite, text))
+
+            # Prevent disconnect-triggered cancellation from clearing in-flight dedupe
+            # state while a background typing thread is still running.
+            try:
+                await asyncio.shield(typing_task)
+            except asyncio.CancelledError:
+                try:
+                    await typing_task
+                except Exception:
+                    pass
+                raise
 
             await _wait_for_typing_settle(text)
             if dedupe_key:
@@ -4190,7 +4201,7 @@ async def post_powershell_exec(payload: Dict[str, Any]):
     
     try:
         # Run in thread pool to avoid blocking
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             executor,
             execute_powershell_command,

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3413,7 +3413,7 @@ def _press_key_with_scancode(key: str, key_up: bool = False):
 
 
 @app.post("/computer/input/keyboard/type")
-async def post_keyboard_type(payload: Dict[str, str]):
+async def post_keyboard_type(request: Request, payload: Dict[str, str]):
     """Type a string of text."""
     text = payload.get("text")
     if not text:
@@ -3423,6 +3423,12 @@ async def post_keyboard_type(payload: Dict[str, str]):
 
     text = _normalize_text_for_keyboard_typing(text)
     text_hash = _hash_keyboard_type_text(text)
+    idempotency_key_raw = request.headers.get("x-idempotency-key")
+    idempotency_key = idempotency_key_raw.strip() if isinstance(idempotency_key_raw, str) else ""
+    # Use idempotency key for retry dedupe when available; otherwise fall back to
+    # payload hash for in-flight protection only.
+    dedupe_key = f"idem:{idempotency_key}" if idempotency_key else f"text:{text_hash}"
+    post_completion_dedupe_enabled = bool(idempotency_key)
     estimated_timeout_seconds = _estimate_keyboard_type_timeout_seconds(text)
     dedupe_window_seconds = max(
         KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS,
@@ -3439,7 +3445,7 @@ async def post_keyboard_type(payload: Dict[str, str]):
     inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
     if (
         isinstance(inflight_hash, str)
-        and inflight_hash == text_hash
+        and inflight_hash == dedupe_key
         and (now - inflight_started) <= KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS
     ):
         print("Duplicate /keyboard/type payload received while identical request is in-flight; skipping retry typing")
@@ -3453,7 +3459,7 @@ async def post_keyboard_type(payload: Dict[str, str]):
         inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
         if (
             isinstance(inflight_hash, str)
-            and inflight_hash == text_hash
+            and inflight_hash == dedupe_key
             and (now - inflight_started) <= KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS
         ):
             print("Duplicate /keyboard/type payload detected after lock acquisition; skipping retry typing")
@@ -3462,14 +3468,15 @@ async def post_keyboard_type(payload: Dict[str, str]):
         last_hash = getattr(app.state, "keyboard_type_last_hash", None)
         last_completed = float(getattr(app.state, "keyboard_type_last_completed_at", 0.0) or 0.0)
         if (
-            isinstance(last_hash, str)
-            and last_hash == text_hash
+            post_completion_dedupe_enabled
+            and isinstance(last_hash, str)
+            and last_hash == dedupe_key
             and (now - last_completed) <= dedupe_window_seconds
         ):
             print("Duplicate /keyboard/type payload received shortly after completion; skipping retry typing")
             return {}
 
-        app.state.keyboard_type_inflight_hash = text_hash
+        app.state.keyboard_type_inflight_hash = dedupe_key
         app.state.keyboard_type_inflight_started_at = now
         try:
             # Ensure Caps Lock is OFF to prevent case inversion
@@ -3488,7 +3495,7 @@ async def post_keyboard_type(payload: Dict[str, str]):
                 await asyncio.to_thread(pyautogui.typewrite, text)
 
             await _wait_for_typing_settle(text)
-            app.state.keyboard_type_last_hash = text_hash
+            app.state.keyboard_type_last_hash = dedupe_key
             app.state.keyboard_type_last_completed_at = time.time()
         finally:
             app.state.keyboard_type_inflight_hash = None

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -48,6 +48,7 @@ import os
 import platform
 import pathlib
 import re
+import secrets
 import socket
 import subprocess
 import sys
@@ -72,7 +73,7 @@ import numpy as np
 import pyautogui
 import pyperclip
 from PIL import Image
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from fastapi.responses import Response, JSONResponse
 import uvicorn
@@ -126,8 +127,20 @@ def _print_with_utc_timestamp(*args, **kwargs):
         _ORIGINAL_PRINT(f"[{_utc_now_iso()}]", **kwargs)
         return
 
-    first_arg = _prefix_log_line_with_utc_timestamp(str(args[0]))
-    _ORIGINAL_PRINT(first_arg, *args[1:], **kwargs)
+    sep = kwargs.get("sep", " ")
+    text_args = [str(arg) for arg in args]
+
+    # If each argument can become its own line (e.g., sep="\n"), prefix each one.
+    if "\n" in sep:
+        prefixed_args = [_prefix_log_line_with_utc_timestamp(text) for text in text_args]
+        _ORIGINAL_PRINT(*prefixed_args, **kwargs)
+        return
+
+    # Otherwise render exactly one output line and prefix it once.
+    rendered = sep.join(text_args)
+    kwargs_single = dict(kwargs)
+    kwargs_single.pop("sep", None)
+    _ORIGINAL_PRINT(_prefix_log_line_with_utc_timestamp(rendered), **kwargs_single)
 
 
 if getattr(builtins.print, "__name__", "") != "_print_with_utc_timestamp":
@@ -2312,15 +2325,63 @@ async def post_remote_keepalive_disable():
         return JSONResponse(status_code=500, content={"error": str(e)})
 
 
-@app.post("/shutdown")
+def _extract_bearer_token(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    parts = value.split(" ", 1)
+    if len(parts) != 2:
+        return None
+    scheme, token = parts[0].strip().lower(), parts[1].strip()
+    if scheme != "bearer" or not token:
+        return None
+    return token
+
+
+def _get_shutdown_auth_token() -> Optional[str]:
+    """Resolve shutdown auth token from env or runtime state."""
+    env_token = os.environ.get("CYBERDRIVER_SHUTDOWN_TOKEN")
+    if env_token:
+        return env_token
+    state_token = getattr(app.state, "shutdown_token", None)
+    if isinstance(state_token, str) and state_token:
+        return state_token
+    return None
+
+
+def _get_shutdown_request_token(request: Request, payload: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Extract shutdown token from Authorization/header/body."""
+    token = _extract_bearer_token(request.headers.get("authorization"))
+    if token:
+        return token
+
+    header_token = request.headers.get("x-cyberdriver-shutdown-token")
+    if header_token:
+        return header_token.strip()
+
+    if isinstance(payload, dict):
+        payload_token = payload.get("token")
+        if payload_token is not None:
+            return str(payload_token).strip()
+
+    return None
+
+
 @app.post("/internal/shutdown")
-async def post_shutdown(payload: Optional[Dict[str, Any]] = None):
+async def post_shutdown(request: Request, payload: Optional[Dict[str, Any]] = None):
     """Request cyberdriver to terminate itself.
 
     Intended for cloud control-plane use when a machine/session is being turned off.
     Returns immediately, then exits the process shortly after the response is sent.
     """
     try:
+        expected_token = _get_shutdown_auth_token()
+        if not expected_token:
+            raise HTTPException(status_code=503, detail="Shutdown token is not configured")
+
+        provided_token = _get_shutdown_request_token(request, payload)
+        if not provided_token or not secrets.compare_digest(provided_token, expected_token):
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
         pid = os.getpid()
         reason = None
         source = "unknown"
@@ -2355,6 +2416,8 @@ async def post_shutdown(payload: Optional[Dict[str, Any]] = None):
             "reason": reason,
             "source": source,
         }
+    except HTTPException:
+        raise
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": str(e)})
 
@@ -3985,7 +4048,21 @@ def _restart_cyberdriver_process() -> bool:
         
     Note: If successful, this function exits the process and never returns.
     """
+    RESTART_WARNING_EVERY = 50
+    RESTART_HISTORY_MAX_BYTES = 1 * 1024 * 1024  # Cap restart-history.log at 1MB
+
     restart_count = _get_restart_count() + 1
+
+    if restart_count >= RESTART_WARNING_EVERY and restart_count % RESTART_WARNING_EVERY == 0:
+        print(f"\n{'='*60}")
+        print("⚠️  High restart count detected")
+        print(f"{'='*60}")
+        print(f"Cyberdriver has restarted {restart_count} times in this recovery chain.")
+        print("The process will keep retrying, but this usually indicates a persistent issue:")
+        print("  1. API/network connectivity problems")
+        print("  2. Persistent local environment corruption")
+        print("  3. Invalid machine configuration")
+        print(f"{'='*60}\n")
 
     print(f"\n{'='*60}")
     print(f"🔄 RESTARTING CYBERDRIVER (attempt #{restart_count})")
@@ -4005,6 +4082,15 @@ def _restart_cyberdriver_process() -> bool:
     # Log the restart for debugging
     try:
         log_path = get_config_dir() / "restart-history.log"
+        try:
+            if log_path.exists() and log_path.stat().st_size > RESTART_HISTORY_MAX_BYTES:
+                with open(log_path, "w", encoding="utf-8") as f:
+                    f.write(
+                        f"[{_utc_now_iso()}] restart-history.log truncated "
+                        f"(exceeded {RESTART_HISTORY_MAX_BYTES} bytes)\n"
+                    )
+        except Exception:
+            pass
         with open(log_path, "a", encoding="utf-8") as f:
             f.write(f"\n[{_utc_now_iso()}] Restarting cyberdriver (attempt #{restart_count})\n")
             f.write(f"Command: {' '.join(cmd)}\n")
@@ -5389,6 +5475,8 @@ async def run_join(host: str, port: int, secret: str, target_port: int, keepaliv
     """Run both API server and tunnel client."""
     # Store connection info for use by update endpoint
     _set_connection_info(host, port)
+    # Use join secret as default auth token for /internal/shutdown.
+    app.state.shutdown_token = secret
     
     config = get_config()
     

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2321,7 +2321,7 @@ async def global_exception_handler(request, exc):
     # Immediately log that we entered this handler
     timestamp = _utc_now_iso()
     try:
-        print(f"\n[GLOBAL EXCEPTION HANDLER] {timestamp}", flush=True)
+        print(f"\n[GLOBAL EXCEPTION HANDLER]", flush=True)
         print(f"[GLOBAL EXCEPTION HANDLER] Exception type: {type(exc).__name__}", flush=True)
         print(f"[GLOBAL EXCEPTION HANDLER] Exception message: {exc}", flush=True)
         sys.stdout.flush()
@@ -2510,9 +2510,11 @@ async def post_shutdown(request: Request, payload: Optional[Dict[str, Any]] = No
                 _remove_pid_file_safely()
             except Exception:
                 pass
-            os._exit(0)
+            # Use a graceful interpreter exit so atexit handlers can flush buffered logs.
+            asyncio.get_running_loop().call_soon(sys.exit, 0)
 
-        asyncio.create_task(_delayed_shutdown())
+        shutdown_task = asyncio.create_task(_delayed_shutdown())
+        app.state.shutdown_task = shutdown_task
         return {
             "status": "shutting_down",
             "pid": pid,
@@ -3456,10 +3458,12 @@ def _press_key_with_scancode(key: str, key_up: bool = False):
 async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
     """Type a string of text."""
     text = payload.get("text")
-    if not text:
+    if text is None:
         raise HTTPException(status_code=400, detail="Missing 'text' field")
     if not isinstance(text, str):
         text = str(text)
+    if not text:
+        raise HTTPException(status_code=400, detail="'text' field must not be empty")
 
     text = _normalize_text_for_keyboard_typing(text)
     idempotency_key_raw = request.headers.get("x-idempotency-key")
@@ -5119,7 +5123,7 @@ class TunnelClient:
             # Log to console with full details
             timestamp = _utc_now_iso()
             print(f"\n{'='*60}", flush=True)
-            print(f"[TUNNEL FORWARD ERROR] {timestamp}", flush=True)
+            print(f"[TUNNEL FORWARD ERROR]", flush=True)
             print(f"Error type: {error_type}", flush=True)
             print(f"Error message: {error_msg}", flush=True)
             print(f"Method: {method}", flush=True)

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3608,8 +3608,8 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
                     # consistent, but holds typing_lock until typing finishes.
                     # Queued /keyboard/type requests can stall during this window.
                     await typing_task
-                except Exception:
-                    pass
+                except Exception as typing_exc:
+                    print(f"Warning: typing task raised during cancellation: {typing_exc}")
                 raise
 
             await _wait_for_typing_settle(text)

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3504,6 +3504,8 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
         raise HTTPException(status_code=400, detail="'text' field must not be empty")
 
     text = _normalize_text_for_keyboard_typing(text)
+    if not text:
+        raise HTTPException(status_code=400, detail="'text' field must not be empty after normalization")
     idempotency_key_raw = request.headers.get("x-idempotency-key")
     idempotency_key = idempotency_key_raw.strip() if isinstance(idempotency_key_raw, str) else ""
     # Keep /keyboard/type retry dedupe simple: idempotency-key only.

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3393,6 +3393,18 @@ async def post_keyboard_type(payload: Dict[str, str]):
 
     async with typing_lock:
         now = time.time()
+        # Re-check in-flight state after acquiring the lock to avoid a race where
+        # two identical requests pass the pre-lock check simultaneously.
+        inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
+        inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
+        if (
+            isinstance(inflight_hash, str)
+            and inflight_hash == text_hash
+            and (now - inflight_started) <= KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS
+        ):
+            print("Duplicate /keyboard/type payload detected after lock acquisition; skipping retry typing")
+            return {}
+
         last_hash = getattr(app.state, "keyboard_type_last_hash", None)
         last_completed = float(getattr(app.state, "keyboard_type_last_completed_at", 0.0) or 0.0)
         if (

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2395,7 +2395,7 @@ async def disable_buffering(request, call_next):
     except Exception:
         # Keep one request outcome line even when downstream raises unexpectedly.
         duration_ms = (time.perf_counter() - request_start) * 1000
-        print(f"{method} {path} -> 500 ({duration_ms:.1f}ms)")
+        print(f"{method} {path} -> ERR ({duration_ms:.1f}ms)")
         raise
 
     duration_ms = (time.perf_counter() - request_start) * 1000
@@ -3567,6 +3567,20 @@ async def post_keyboard_type(request: Request, payload: Dict[str, Any]):
                 # SendInput failure, which can duplicate already-queued chars.
                 await asyncio.to_thread(_type_with_win32_sendinput, text)
             else:
+                non_ascii_chars: Dict[str, int] = {}
+                for ch in text:
+                    if ord(ch) > 127:
+                        non_ascii_chars[ch] = non_ascii_chars.get(ch, 0) + 1
+                if non_ascii_chars:
+                    skipped_count = sum(non_ascii_chars.values())
+                    top_items = sorted(non_ascii_chars.items(), key=lambda item: item[1], reverse=True)[:5]
+                    summary = ", ".join(f"{repr(ch)} x{count}" for ch, count in top_items)
+                    remaining = len(non_ascii_chars) - len(top_items)
+                    extra = f" (+{remaining} more)" if remaining > 0 else ""
+                    print(
+                        f"Warning: pyautogui.typewrite may skip {skipped_count} non-ASCII character(s): "
+                        f"{summary}{extra}"
+                    )
                 await asyncio.to_thread(pyautogui.typewrite, text)
 
             await _wait_for_typing_settle(text)
@@ -6263,7 +6277,6 @@ def check_mei_health(context: str = "") -> bool:
             missing.append(d)
     
     if missing:
-        from datetime import datetime
         timestamp = _utc_now_iso()
         
         # Get list of existing directories for debugging

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2350,14 +2350,17 @@ async def disable_buffering(request, call_next):
     """Log every request once and ensure responses are not buffered."""
     method = request.method
     path = request.url.path
+    request_start = time.perf_counter()
     try:
         response = await call_next(request)
     except Exception:
         # Keep one request outcome line even when downstream raises unexpectedly.
-        print(f"{method} {path} -> 500")
+        duration_ms = (time.perf_counter() - request_start) * 1000
+        print(f"{method} {path} -> 500 ({duration_ms:.1f}ms)")
         raise
 
-    print(f"{method} {path} -> {response.status_code}")
+    duration_ms = (time.perf_counter() - request_start) * 1000
+    print(f"{method} {path} -> {response.status_code} ({duration_ms:.1f}ms)")
     # Add headers to disable any proxy buffering
     response.headers["X-Accel-Buffering"] = "no"
     response.headers["Cache-Control"] = "no-cache"

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -42,6 +42,7 @@ import argparse
 import asyncio
 import base64
 import builtins
+import hashlib
 import json
 import math
 import os
@@ -2081,11 +2082,34 @@ def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
 # delay to reduce races with immediate follow-up actions/screenshots.
 TYPING_SETTLE_BASE_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_BASE_SECONDS", 0.05)
 TYPING_SETTLE_PER_CHAR_SECONDS = _get_env_float("CYBERDRIVER_TYPING_SETTLE_PER_CHAR_SECONDS", 0.007)
+KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE", 0.004
+)
+KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS", 8.0
+)
+KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS", 5.0
+)
+KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS = _get_env_float(
+    "CYBERDRIVER_KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS", 300.0, minimum=1.0
+)
 
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
     return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
+
+
+def _hash_keyboard_type_text(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8", errors="replace")).hexdigest()
+
+
+def _estimate_keyboard_type_timeout_seconds(text: str) -> float:
+    char_count = len(text or "")
+    estimated_typing_seconds = char_count * KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE
+    settle_seconds = _compute_typing_settle_delay(text)
+    return max(30.0, estimated_typing_seconds + settle_seconds + KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS)
 
 
 async def _wait_for_typing_settle(text: str) -> None:
@@ -2103,6 +2127,11 @@ async def lifespan(app: FastAPI):
     """Manage application lifespan events."""
     # Startup
     app.state.start_time = time.time()
+    app.state.keyboard_type_lock = asyncio.Lock()
+    app.state.keyboard_type_inflight_hash = None
+    app.state.keyboard_type_inflight_started_at = 0.0
+    app.state.keyboard_type_last_hash = None
+    app.state.keyboard_type_last_completed_at = 0.0
     yield
     # Shutdown
     print("Shutting down...")
@@ -3341,23 +3370,63 @@ async def post_keyboard_type(payload: Dict[str, str]):
     text = payload.get("text")
     if not text:
         raise HTTPException(status_code=400, detail="Missing 'text' field")
-    
-    # Ensure Caps Lock is OFF to prevent case inversion
-    await _ensure_capslock_off()
-    
-    # On Windows: use native SendInput with scan codes (Citrix-compatible)
-    # On macOS/Linux: use PyAutoGUI
-    if platform.system() == "Windows":
-        try:
-            _type_with_win32_sendinput(text)
-            await _wait_for_typing_settle(text)
+    if not isinstance(text, str):
+        text = str(text)
+
+    text_hash = _hash_keyboard_type_text(text)
+
+    typing_lock: Optional[asyncio.Lock] = getattr(app.state, "keyboard_type_lock", None)
+    if typing_lock is None:
+        typing_lock = asyncio.Lock()
+        app.state.keyboard_type_lock = typing_lock
+
+    now = time.time()
+    inflight_hash = getattr(app.state, "keyboard_type_inflight_hash", None)
+    inflight_started = float(getattr(app.state, "keyboard_type_inflight_started_at", 0.0) or 0.0)
+    if (
+        isinstance(inflight_hash, str)
+        and inflight_hash == text_hash
+        and (now - inflight_started) <= KEYBOARD_TYPE_INFLIGHT_DEDUPE_MAX_SECONDS
+    ):
+        print("Duplicate /keyboard/type payload received while identical request is in-flight; skipping retry typing")
+        return {}
+
+    async with typing_lock:
+        now = time.time()
+        last_hash = getattr(app.state, "keyboard_type_last_hash", None)
+        last_completed = float(getattr(app.state, "keyboard_type_last_completed_at", 0.0) or 0.0)
+        if (
+            isinstance(last_hash, str)
+            and last_hash == text_hash
+            and (now - last_completed) <= KEYBOARD_TYPE_DEDUPE_WINDOW_SECONDS
+        ):
+            print("Duplicate /keyboard/type payload received shortly after completion; skipping retry typing")
             return {}
-        except Exception as e:
-            print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
-    
-    # Fallback for non-Windows or if SendInput fails
-    pyautogui.typewrite(text)
-    await _wait_for_typing_settle(text)
+
+        app.state.keyboard_type_inflight_hash = text_hash
+        app.state.keyboard_type_inflight_started_at = now
+        try:
+            # Ensure Caps Lock is OFF to prevent case inversion
+            await _ensure_capslock_off()
+
+            # Run keyboard typing in a worker thread so long inputs don't block the event loop.
+            # This keeps tunnel I/O responsive while typing and reduces cascading timeouts.
+            if platform.system() == "Windows":
+                try:
+                    await asyncio.to_thread(_type_with_win32_sendinput, text)
+                except Exception as e:
+                    print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
+                    await asyncio.to_thread(pyautogui.typewrite, text)
+            else:
+                await asyncio.to_thread(pyautogui.typewrite, text)
+
+            await _wait_for_typing_settle(text)
+            app.state.keyboard_type_last_hash = text_hash
+            app.state.keyboard_type_last_completed_at = time.time()
+        finally:
+            app.state.keyboard_type_inflight_hash = None
+            app.state.keyboard_type_inflight_started_at = 0.0
+
     return {}
 
 
@@ -4829,6 +4898,7 @@ class TunnelClient:
             url += f"?{query}"
         
         # For PowerShell exec requests, extract timeout from body and use custom client
+        # For keyboard type requests, compute timeout based on text length
         # For all other requests, use the default client with 30s timeout
         use_custom_timeout = False
         request_timeout = 30.0
@@ -4840,6 +4910,15 @@ class TunnelClient:
                     # The local FastAPI will timeout the subprocess at exactly `timeout` seconds,
                     # so we need to wait slightly longer to receive that response 
                     request_timeout = float(payload["timeout"]) + 3.0  # 3s buffer for local processing
+                    use_custom_timeout = True
+            except Exception:
+                pass  # Fall back to default client if parsing fails
+        elif path == "/computer/input/keyboard/type" and body:
+            try:
+                payload = json.loads(body.decode('utf-8'))
+                text = payload.get("text")
+                if isinstance(text, str):
+                    request_timeout = _estimate_keyboard_type_timeout_seconds(text)
                     use_custom_timeout = True
             except Exception:
                 pass  # Fall back to default client if parsing fails

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -2124,7 +2124,7 @@ UNICODE_TYPING_REPLACEMENTS = (
 
 def _compute_typing_settle_delay(text: str) -> float:
     char_count = len(text or "")
-    linear_threshold = max(0, int(TYPING_SETTLE_LINEAR_THRESHOLD_CHARS))
+    linear_threshold = TYPING_SETTLE_LINEAR_THRESHOLD_CHARS
     if char_count <= linear_threshold:
         return max(0.0, TYPING_SETTLE_BASE_SECONDS + (char_count * TYPING_SETTLE_PER_CHAR_SECONDS))
 
@@ -2151,6 +2151,14 @@ def _normalize_text_for_keyboard_typing(text: str) -> str:
 def _estimate_keyboard_type_timeout_seconds(text: str) -> float:
     char_count = len(text or "")
     estimated_typing_seconds = char_count * KEYBOARD_TYPE_SECONDS_PER_CHAR_ESTIMATE
+    # Windows long-text typing may include per-key pacing in SendInput mode.
+    # Include that extra time so timeout/dedupe windows track actual duration.
+    if (
+        platform.system() == "Windows"
+        and char_count >= WINDOWS_SENDINPUT_DELAY_THRESHOLD_CHARS
+        and WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS > 0
+    ):
+        estimated_typing_seconds += char_count * WINDOWS_SENDINPUT_INTER_KEY_DELAY_SECONDS
     settle_seconds = _compute_typing_settle_delay(text)
     return max(30.0, estimated_typing_seconds + settle_seconds + KEYBOARD_TYPE_TIMEOUT_BUFFER_SECONDS)
 
@@ -3336,6 +3344,8 @@ def _type_with_win32_sendinput(text: str):
         if char == ' ' and EXPERIMENTAL_SPACE_ENABLED:
             _win32_send_vk_space(key_up=False)
             _win32_send_vk_space(key_up=True)
+            if inter_key_delay > 0:
+                time.sleep(inter_key_delay)
             continue
         
         upper_char = char.upper()


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps cyberdriver to v0.0.40 with four main additions: (1) a UTC-timestamped logging layer that monkey-patches `builtins.print` so every console line is automatically prefixed; (2) keyboard-type idempotency/deduplication keyed on `x-idempotency-key`, using an `asyncio.Lock` and three-phase dedup (pre-lock, post-lock in-flight, post-completion window); (3) a tunnel-only `/internal/shutdown` endpoint gated by a per-session `secrets.token_hex(32)` token injected by `TunnelClient`; and (4) a configurable `CYBERDRIVER_MAX_RESTARTS` env-var (defaulting to unlimited) replacing the previous hard-coded limit of 5.

Key observations:
- The `CyberdeskTransfers` fallback path in `post_fs_write` was silently broken in previous versions (the old check `str(safe_path.parent) == "."` was always `False` after `.resolve()`); the new logic correctly detects bare filenames before resolving.
- The backoff `sleep_time` was never reset after a stable reconnection — now it is, which will improve recovery latency after temporary outages.
- Windows `SendInput` no longer falls back to `pyautogui` on failure; callers should treat a `500` from `/computer/input/keyboard/type` as "partial state unknown" rather than "nothing typed."
- Several previously-flagged issues (double timestamps, unbounded restart loop, module-level lock creation, `os._exit` vs `sys.exit`) have been addressed or partially addressed in this revision.
- The `asyncio.CancelledError` that `typing_task` could itself raise inside the `except asyncio.CancelledError` handler is not caught by `except Exception`, potentially leaving dedupe state inconsistent in rare edge cases.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with awareness of the keyboard-type dedup edge case and the intentional removal of the Windows SendInput pyautogui fallback.
- The core features (timestamping, shutdown endpoint, dedup) are well-structured and most previously-flagged issues have been addressed. Two items reduce confidence: (1) the `BaseException` gap in the `CancelledError` handler for `typing_task` could cause silent dedupe-state inconsistency; (2) removing the Windows SendInput fallback changes observable failure semantics for callers. Neither is a crash-level regression, but both affect production typing reliability.
- cyberdriver.py — specifically the `post_keyboard_type` handler's CancelledError path and the `/internal/shutdown` fallback-exit chain.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Simple version bump from v0.0.39 to v0.0.40 in both PowerShell and bash install snippets. No issues found. |
| cyberdriver.py | Large change adding UTC timestamped logging via builtins.print monkey-patch, keyboard-type idempotency/deduplication with asyncio.Lock, a tunnel-authenticated /internal/shutdown endpoint, CyberdeskTransfers directory auto-creation, configurable CYBERDRIVER_MAX_RESTARTS, and sleep-time reset after stable reconnections. Several edge cases (task reference, shutdown fallback chain, dedupe on CancelledError) warrant attention; most critical pre-existing issues have been addressed in earlier threads. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CP as Cloud Control Plane
    participant TS as Tunnel Server (remote)
    participant TC as TunnelClient (local)
    participant FA as FastAPI /internal/shutdown
    participant EL as Event Loop

    CP->>TS: POST shutdown (HTTP)
    TS->>TC: WebSocket message (path=/internal/shutdown)
    Note over TC: path == "/internal/shutdown"<br/>injects x-cyberdesk-tunnel-token header
    TC->>FA: POST /internal/shutdown + token header
    FA->>FA: _is_request_from_active_tunnel()<br/>secrets.compare_digest(provided, expected)
    alt token invalid or missing
        FA-->>TC: 403 Forbidden
    else already shutting down
        FA-->>TC: 200 already_shutting_down
    else token valid
        FA->>FA: app.state.shutdown_requested = True
        FA->>EL: asyncio.create_task(_delayed_shutdown)
        FA-->>TC: 200 shutting_down
        TC-->>TS: response forwarded
        TS-->>CP: response forwarded
        Note over EL: await asyncio.sleep(0.25)
        EL->>EL: _remove_pid_file_safely()
        EL->>EL: loop.call_soon(sys.exit, 0)
        EL->>EL: loop.call_later(2.0, _fallback_exit_process)
        alt sys.exit succeeds
            EL->>EL: Process exits gracefully
        else sys.exit intercepted
            EL->>EL: _fallback_exit_process runs
            EL->>EL: loop.call_later(2.0, os._exit, 0)
            EL->>EL: sys.exit(0) attempt 2
            alt still alive after 2s
                EL->>EL: os._exit(0) — forced termination
            end
        end
    end
```

<sub>Last reviewed commit: 1868aa6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->