### PR TITLE
Cyberdriver websocket retries

### DIFF
--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -4685,11 +4685,12 @@ class TunnelClient:
                     close_code=close_code
                 )
                 
-                # Only reset failure counter if connection lasted more than 10 seconds
-                # Short-lived connections indicate an ongoing problem
+                # After a stable connection, reset all retry/backoff state.
+                # Short-lived connections indicate an ongoing problem.
                 if connection_duration > 10:
                     self._consecutive_failures = 0
                     failures_at_max_sleep = 0
+                    sleep_time = self.min_sleep
                     # Reset restart count since we had a successful long connection
                     # This clears the CYBERDRIVER_RESTART_COUNT env var
                     if "CYBERDRIVER_RESTART_COUNT" in os.environ:
@@ -4839,6 +4840,7 @@ class TunnelClient:
                 if connection_duration > 10:
                     self._consecutive_failures = 0
                     failures_at_max_sleep = 0
+                    sleep_time = self.min_sleep
                     # Reset restart count since we had a successful long connection
                     if "CYBERDRIVER_RESTART_COUNT" in os.environ:
                         del os.environ["CYBERDRIVER_RESTART_COUNT"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reset websocket reconnect backoff to minimum after a stable connection to improve failover recovery time.

---
<p><a href="https://cursor.com/agents/bc-2d974301-3c2b-4064-ab50-344f21b8db0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d974301-3c2b-4064-ab50-344f21b8db0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the backoff reset logic in `TunnelClient.run()` by adding `sleep_time = self.min_sleep` alongside the existing `_consecutive_failures` and `failures_at_max_sleep` resets whenever a stable connection (lasting >10 seconds) drops. Previously, only the failure counters were reset, leaving `sleep_time` at whatever elevated value it had accumulated from prior failures — meaning the first reconnect attempt after a healthy connection unexpectedly dropped could still incur a long delay.

Key points:
- The fix is applied symmetrically in both exception handlers (`ConnectionClosed`/`InvalidStatus` and generic `Exception`).
- After the reset, the jitter calculation at the bottom of each handler correctly uses the now-minimal `sleep_time`, so the immediate reconnect uses `min_sleep + jitter` as intended.
- Subsequent failures (if the reconnect itself is short-lived) will again ramp up via normal exponential doubling (`sleep_time = min(sleep_time * 2, max_sleep)`).
- No logic issues, race conditions (asyncio is single-threaded), or edge cases identified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is minimal, targeted, and correctly closes a gap in the backoff-reset logic.
- Only two lines are added, both in symmetric positions across two exception handlers. The fix is logically consistent with the surrounding code: `sleep_time` is reset to `min_sleep` before the jitter calculation, so the very next reconnect correctly uses minimum backoff. No new branches, no state mutations outside the existing `if connection_duration > 10:` guard, and no impact on authentication or rate-limit paths.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cyberdriver.py | Adds `sleep_time = self.min_sleep` reset in two stable-connection branches (ConnectionClosed/InvalidStatus handler and generic Exception handler) so exponential backoff is fully reset after a long-lived connection drops, not just the failure counters. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as TunnelClient.run()
    participant WS as WebSocket (_connect_and_run)

    loop Reconnect Loop
        Client->>WS: Connect
        alt Stable connection (>10s) then closes
            WS-->>Client: ConnectionClosed / Exception
            Note over Client: connection_duration > 10s
            Client->>Client: _consecutive_failures = 0
            Client->>Client: failures_at_max_sleep = 0
            Client->>Client: sleep_time = min_sleep  ← NEW
            Client->>Client: Sleep min_sleep + jitter
        else Unstable connection (≤10s) then closes
            WS-->>Client: ConnectionClosed / Exception
            Note over Client: connection_duration ≤ 10s
            Client->>Client: _consecutive_failures += 1
            Client->>Client: Sleep current sleep_time + jitter
            Client->>Client: sleep_time = min(sleep_time * 2, max_sleep)
        end
        Client->>WS: Reconnect
    end
```

<sub>Last reviewed commit: 31eea17</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->