### PR TITLE
Update error message for Cyberdriver download failure to include inst…

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ New-Item -ItemType Directory -Force -Path $toolDir
 try {
     Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.40/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe" -ErrorAction Stop
 } catch {
-    Write-Host "ERROR: Failed to download Cyberdriver. Please check your internet connection and try again." -ForegroundColor Red
+    Write-Host "ERROR: Failed to download Cyberdriver. If Cyberdriver is already running, run 'cyberdriver stop' first. Otherwise, check your internet connection and try again." -ForegroundColor Red
     return
 }
 


### PR DESCRIPTION
…ructions for running 'cyberdriver stop' if already active

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the error message shown when the Cyberdriver Windows installation script fails to download the binary. The change adds actionable guidance for the common scenario where the download fails because `cyberdriver.exe` is already running and its file is locked by Windows, preventing `Invoke-WebRequest` from writing a new copy to the same path.

**Changes:**
- Updated the `catch` block error message in the Windows PowerShell installation snippet in `README.md` to instruct users to run `cyberdriver stop` before retrying if Cyberdriver is already active.

**Rationale:**
On Windows, a running executable holds a file lock on its `.exe`, which would cause `Invoke-WebRequest -OutFile` to throw and be caught here. Stopping the process first releases the lock, allowing the installation to proceed. The macOS/Bash installation section lacks equivalent error handling around the `curl` download, but that is out of scope for this PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a documentation-only change with no impact on executable code.
- The change touches only a single string literal in the README. The updated message is accurate (a locked `.exe` from a running process is a real cause of download failure on Windows) and provides clear, actionable guidance. There are no logic, syntax, or security concerns.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run PowerShell Installation Script] --> B[Create ~/.cyberdriver directory]
    B --> C{Invoke-WebRequest<br/>Download cyberdriver.exe}
    C -- Success --> D[Verify file exists]
    C -- Failure --> E["ERROR: Failed to download Cyberdriver.<br/>If already running, run 'cyberdriver stop' first.<br/>Otherwise, check internet connection."]
    E --> F[return / exit script]
    D --> G{File size > 34 MB?}
    G -- Yes --> H[Add to PATH if not already present]
    H --> I[Print success message]
    G -- No --> J[ERROR: Download incomplete - file too small]
```

<sub>Last reviewed commit: 8737fc6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->