### PR TITLE
Arrow right support and other common sequences for key presses

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ New-Item -ItemType Directory -Force -Path $toolDir
 
 # Download cyberdriver
 try {
-    Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.40/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe" -ErrorAction Stop
+    Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.41/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe" -ErrorAction Stop
 } catch {
     Write-Host "ERROR: Failed to download Cyberdriver. If Cyberdriver is already running, run 'cyberdriver stop' first. Otherwise, check your internet connection and try again." -ForegroundColor Red
     return
@@ -77,7 +77,7 @@ if (Test-Path "$toolDir\cyberdriver.exe") {
 
 ```bash
 # Choose version and target directory
-VERSION=0.0.40
+VERSION=0.0.41
 TOOL_DIR="$HOME/.cyberdriver"
 mkdir -p "$TOOL_DIR"
 
@@ -188,7 +188,7 @@ Invoke-RestMethod -Method Post -Uri "http://localhost:3000/internal/update" -Con
 Or specify a specific version:
 
 ```powershell
-Invoke-RestMethod -Method Post -Uri "http://localhost:3000/internal/update" -ContentType "application/json" -Body '{"version":"0.0.34","restart":true}'
+Invoke-RestMethod -Method Post -Uri "http://localhost:3000/internal/update" -ContentType "application/json" -Body '{"version":"0.0.41","restart":true}'
 ```
 
 ### Via Cyberdesk API

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -3623,7 +3623,42 @@ def _press_key_with_scancode(key: str, key_up: bool = False):
         key: Key name (e.g., 'tab', 'ctrl', 'a')
         key_up: True to release, False to press
     """
+    raw_key = (key or "").strip().lower()
     key_lower = _canonicalize_keyboard_key(key)
+    modifier_aliases = {
+        'leftcontrol': 'lcontrol',
+        'controlleft': 'lcontrol',
+        'leftctrl': 'lcontrol',
+        'ctrlleft': 'lcontrol',
+        'rightcontrol': 'rcontrol',
+        'controlright': 'rcontrol',
+        'rightctrl': 'rcontrol',
+        'ctrlright': 'rcontrol',
+        'leftalt': 'lalt',
+        'altleft': 'lalt',
+        'rightalt': 'ralt',
+        'altright': 'ralt',
+        'leftshift': 'lshift',
+        'shiftleft': 'lshift',
+        'rightshift': 'rshift',
+        'shiftright': 'rshift',
+        'leftcommand': 'lwin',
+        'commandleft': 'lwin',
+        'leftcmd': 'lwin',
+        'cmdleft': 'lwin',
+        'rightcommand': 'rwin',
+        'commandright': 'rwin',
+        'rightcmd': 'rwin',
+        'cmdright': 'rwin',
+        'leftwindows': 'lwin',
+        'windowsleft': 'lwin',
+        'leftwin': 'lwin',
+        'winleft': 'lwin',
+        'rightwindows': 'rwin',
+        'windowsright': 'rwin',
+        'rightwin': 'rwin',
+        'winright': 'rwin',
+    }
     
     # Handle space specially when experimental mode is enabled
     if key_lower == 'space' and EXPERIMENTAL_SPACE_ENABLED:
@@ -3631,11 +3666,23 @@ def _press_key_with_scancode(key: str, key_up: bool = False):
         return
     
     # Check all scan code maps
-    scan_code = (MODIFIER_SCANCODES.get(key_lower) or 
-                 SPECIAL_KEY_SCANCODES.get(key_lower) or
-                 LETTER_SCANCODES.get(key_lower.upper()) or
-                 NUMBER_SCANCODES.get(key_lower) or
-                 SYMBOL_SCANCODES.get(key_lower))
+    scan_code = None
+    raw_variants = [raw_key]
+    if len(raw_key) > 1:
+        underscored = raw_key.replace("-", "_").replace(" ", "_")
+        raw_variants.extend([underscored, underscored.replace("_", "")])
+
+    for raw_variant in dict.fromkeys(raw_variants):
+        modifier_key = modifier_aliases.get(raw_variant, raw_variant)
+        scan_code = MODIFIER_SCANCODES.get(modifier_key)
+        if scan_code is not None:
+            break
+
+    if scan_code is None:
+        scan_code = (SPECIAL_KEY_SCANCODES.get(key_lower) or
+                     LETTER_SCANCODES.get(key_lower.upper()) or
+                     NUMBER_SCANCODES.get(key_lower) or
+                     SYMBOL_SCANCODES.get(key_lower))
     
     if scan_code is None:
         raise ValueError(f"Unknown key: {key}")

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -1994,20 +1994,168 @@ class KeyEvent:
         self.down = down
 
 
+XDO_MODIFIER_KEYS = {'ctrl', 'alt', 'shift', 'win'}
+
+# Normalize common multi-word key names before tokenization so model outputs like
+# "ctrl + arrow right" or "page down" still parse as a single key.
+XDO_MULTIWORD_KEY_ALIASES = (
+    (r"\barrow\s+up\b", "arrow_up"),
+    (r"\barrow\s+down\b", "arrow_down"),
+    (r"\barrow\s+left\b", "arrow_left"),
+    (r"\barrow\s+right\b", "arrow_right"),
+    (r"\bup\s+arrow\b", "up_arrow"),
+    (r"\bdown\s+arrow\b", "down_arrow"),
+    (r"\bleft\s+arrow\b", "left_arrow"),
+    (r"\bright\s+arrow\b", "right_arrow"),
+    (r"\bpage\s+up\b", "page_up"),
+    (r"\bpage\s+down\b", "page_down"),
+    (r"\bcaps\s+lock\b", "caps_lock"),
+    (r"\bspace\s+bar\b", "spacebar"),
+    (r"\bback\s+space\b", "backspace"),
+)
+
+# Canonical key aliases shared across parsing and backend dispatch so Windows
+# SendInput and the PyAutoGUI fallback accept the same model-generated names.
+XDO_KEY_ALIASES = {
+    # Modifiers
+    'control': 'ctrl',
+    'ctl': 'ctrl',
+    'leftcontrol': 'ctrl',
+    'controlleft': 'ctrl',
+    'leftctrl': 'ctrl',
+    'ctrlleft': 'ctrl',
+    'lcontrol': 'ctrl',
+    'lctrl': 'ctrl',
+    'rightcontrol': 'ctrl',
+    'controlright': 'ctrl',
+    'rightctrl': 'ctrl',
+    'ctrlright': 'ctrl',
+    'rcontrol': 'ctrl',
+    'rctrl': 'ctrl',
+    'alternate': 'alt',
+    'option': 'alt',
+    'opt': 'alt',
+    'leftalt': 'alt',
+    'altleft': 'alt',
+    'lalt': 'alt',
+    'rightalt': 'alt',
+    'altright': 'alt',
+    'ralt': 'alt',
+    'leftshift': 'shift',
+    'shiftleft': 'shift',
+    'lshift': 'shift',
+    'rightshift': 'shift',
+    'shiftright': 'shift',
+    'rshift': 'shift',
+    'command': 'win',
+    'cmd': 'win',
+    'meta': 'win',
+    'super': 'win',
+    'windows': 'win',
+    'window': 'win',
+    'leftcommand': 'win',
+    'commandleft': 'win',
+    'leftcmd': 'win',
+    'cmdleft': 'win',
+    'rightcommand': 'win',
+    'commandright': 'win',
+    'rightcmd': 'win',
+    'cmdright': 'win',
+    'leftwindows': 'win',
+    'windowsleft': 'win',
+    'leftwin': 'win',
+    'winleft': 'win',
+    'lwin': 'win',
+    'rightwindows': 'win',
+    'windowsright': 'win',
+    'rightwin': 'win',
+    'winright': 'win',
+    'rwin': 'win',
+    # Navigation and editing keys
+    'escape': 'esc',
+    'return': 'enter',
+    'spacebar': 'space',
+    'space_bar': 'space',
+    'back_space': 'backspace',
+    'bksp': 'backspace',
+    'del': 'delete',
+    'ins': 'insert',
+    'page_up': 'pageup',
+    'pgup': 'pageup',
+    'page_down': 'pagedown',
+    'pgdn': 'pagedown',
+    'pgdown': 'pagedown',
+    'caps_lock': 'capslock',
+    # Arrow key variants often emitted by models
+    'arrowup': 'up',
+    'arrow_up': 'up',
+    'uparrow': 'up',
+    'up_arrow': 'up',
+    'arrowdown': 'down',
+    'arrow_down': 'down',
+    'downarrow': 'down',
+    'down_arrow': 'down',
+    'arrowleft': 'left',
+    'arrow_left': 'left',
+    'leftarrow': 'left',
+    'left_arrow': 'left',
+    'arrowright': 'right',
+    'arrow_right': 'right',
+    'rightarrow': 'right',
+    'right_arrow': 'right',
+}
+
+
+def _normalize_xdo_sequence(sequence: str) -> str:
+    """Normalize an XDO-style sequence before tokenization."""
+    normalized = (sequence or "").strip()
+    normalized = re.sub(r"\s*\+\s*", "+", normalized)
+    normalized = re.sub(r"\s+", " ", normalized)
+    for pattern, replacement in XDO_MULTIWORD_KEY_ALIASES:
+        normalized = re.sub(pattern, replacement, normalized, flags=re.IGNORECASE)
+    return normalized
+
+
+def _canonicalize_keyboard_key(key: str) -> str:
+    """Collapse common aliases to one canonical key name."""
+    raw = (key or "").strip().lower()
+    if not raw:
+        return ""
+
+    variants = [raw]
+    if len(raw) > 1:
+        underscored = raw.replace("-", "_").replace(" ", "_")
+        variants.append(underscored)
+        variants.append(underscored.replace("_", ""))
+
+    seen = set()
+    for variant in variants:
+        if variant in seen:
+            continue
+        seen.add(variant)
+        canonical = XDO_KEY_ALIASES.get(variant)
+        if canonical:
+            return canonical
+
+    if len(raw) > 1:
+        return raw.replace("-", "_").replace(" ", "_").replace("_", "")
+    return raw
+
+
 class XDOParser:
     """Parse XDO-style keyboard sequences like 'ctrl+c ctrl+v'."""
     
-    MODIFIERS = {'ctrl', 'alt', 'shift', 'win', 'cmd', 'super', 'meta'}
+    MODIFIERS = XDO_MODIFIER_KEYS
     
     @staticmethod
     def parse(sequence: str) -> List[List[KeyEvent]]:
         """Parse XDO sequence into a list of key event groups."""
-        commands = sequence.strip().split()
+        commands = _normalize_xdo_sequence(sequence).split()
         result = []
         
         for command in commands:
             events = []
-            parts = [p.lower() for p in command.split('+')]
+            parts = [_canonicalize_keyboard_key(p) for p in command.split('+') if p.strip()]
             
             # Separate modifiers from regular keys
             modifiers = [p for p in parts if p in XDOParser.MODIFIERS]
@@ -2044,11 +2192,7 @@ def execute_xdo_sequence(sequence: str):
         try:
             for group in command_groups:
                 for event in group:
-                    key = event.key
-                    if key == 'cmd':
-                        key = 'win'
-                    
-                    _press_key_with_scancode(key, key_up=not event.down)
+                    _press_key_with_scancode(event.key, key_up=not event.down)
             return
         except Exception as e:
             print(f"Warning: SendInput failed ({e}), falling back to PyAutoGUI")
@@ -2056,14 +2200,10 @@ def execute_xdo_sequence(sequence: str):
     # Fallback: use PyAutoGUI (for macOS/Linux or if SendInput fails)
     for group in command_groups:
         for event in group:
-            key = event.key
-            if key == 'cmd':
-                key = 'win'
-            
             if event.down:
-                pyautogui.keyDown(key)
+                pyautogui.keyDown(event.key)
             else:
-                pyautogui.keyUp(key)
+                pyautogui.keyUp(event.key)
 
 
 # -----------------------------------------------------------------------------
@@ -3483,9 +3623,7 @@ def _press_key_with_scancode(key: str, key_up: bool = False):
         key: Key name (e.g., 'tab', 'ctrl', 'a')
         key_up: True to release, False to press
     """
-    # Normalize key name: lowercase and remove underscores
-    # This allows both "Page_Down" and "pagedown" to work
-    key_lower = key.lower().replace('_', '')
+    key_lower = _canonicalize_keyboard_key(key)
     
     # Handle space specially when experimental mode is enabled
     if key_lower == 'space' and EXPERIMENTAL_SPACE_ENABLED:
@@ -3495,9 +3633,9 @@ def _press_key_with_scancode(key: str, key_up: bool = False):
     # Check all scan code maps
     scan_code = (MODIFIER_SCANCODES.get(key_lower) or 
                  SPECIAL_KEY_SCANCODES.get(key_lower) or
-                 LETTER_SCANCODES.get(key.upper()) or
-                 NUMBER_SCANCODES.get(key) or
-                 SYMBOL_SCANCODES.get(key))
+                 LETTER_SCANCODES.get(key_lower.upper()) or
+                 NUMBER_SCANCODES.get(key_lower) or
+                 SYMBOL_SCANCODES.get(key_lower))
     
     if scan_code is None:
         raise ValueError(f"Unknown key: {key}")

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -1490,7 +1490,7 @@ async def connect_with_headers(uri, headers_dict):
 CONFIG_DIR = ".cyberdriver"
 CONFIG_FILE = "config.json"
 PID_FILE = "cyberdriver.pid.json"
-VERSION = "0.0.40"
+VERSION = "0.0.41"
 
 @dataclass
 class Config:
@@ -2890,7 +2890,7 @@ async def _resolve_latest_version() -> Optional[str]:
 
 
 class UpdateRequest(BaseModel):
-    version: str = Field(default="latest", description="Target version (e.g. '0.0.34') or 'latest'")
+    version: str = Field(default="latest", description="Target version (e.g. '0.0.41') or 'latest'")
     restart: bool = Field(default=True, description="Whether to restart Cyberdriver after update")
 
 
@@ -2907,16 +2907,16 @@ async def post_update(payload: UpdateRequest = UpdateRequest()):
     
     Request body (optional):
     {
-        "version": "0.0.34",  // Target version (without 'v' prefix), or "latest" (default)
+        "version": "0.0.41",  // Target version (without 'v' prefix), or "latest" (default)
         "restart": true       // Whether to restart after update (default: true)
     }
     
     Returns:
     {
         "status": "update_initiated",
-        "current_version": "0.0.34",
-        "target_version": "0.0.34",
-        "message": "Updating to v0.0.34. Cyberdriver will restart automatically."
+        "current_version": "0.0.41",
+        "target_version": "0.0.41",
+        "message": "Updating to v0.0.41. Cyberdriver will restart automatically."
     }
     """
     if platform.system() != "Windows":

--- a/tests/test_keyboard_key_aliases.py
+++ b/tests/test_keyboard_key_aliases.py
@@ -1,0 +1,139 @@
+import ast
+import re
+import types
+import unittest
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_PATH = Path(__file__).resolve().parents[1] / "cyberdriver.py"
+
+TARGET_ASSIGNMENTS = {
+    "XDO_MODIFIER_KEYS",
+    "XDO_MULTIWORD_KEY_ALIASES",
+    "XDO_KEY_ALIASES",
+    "EXPERIMENTAL_SPACE_ENABLED",
+    "LETTER_SCANCODES",
+    "NUMBER_SCANCODES",
+    "SYMBOL_SCANCODES",
+    "SPECIAL_KEY_SCANCODES",
+    "MODIFIER_SCANCODES",
+}
+TARGET_FUNCTIONS = {
+    "_normalize_xdo_sequence",
+    "_canonicalize_keyboard_key",
+    "execute_xdo_sequence",
+    "_press_key_with_scancode",
+}
+TARGET_CLASSES = {"KeyEvent", "XDOParser"}
+
+
+def _load_keyboard_namespace():
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    module = ast.parse(source, filename=str(SOURCE_PATH))
+    selected_nodes = []
+
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            target_names = {
+                target.id
+                for target in node.targets
+                if isinstance(target, ast.Name)
+            }
+            if target_names & TARGET_ASSIGNMENTS:
+                selected_nodes.append(node)
+        elif isinstance(node, ast.ClassDef) and node.name in TARGET_CLASSES:
+            selected_nodes.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in TARGET_FUNCTIONS:
+            selected_nodes.append(node)
+
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    namespace = {
+        "Dict": Dict,
+        "List": List,
+        "platform": types.SimpleNamespace(system=lambda: "Linux"),
+        "pyautogui": types.SimpleNamespace(keyDown=lambda key: None, keyUp=lambda key: None),
+        "re": re,
+    }
+    exec(compile(extracted_module, str(SOURCE_PATH), "exec"), namespace)
+    return namespace
+
+
+def _event_tuples(group):
+    return [(event.key, event.down) for event in group]
+
+
+class KeyboardAliasTests(unittest.TestCase):
+    def test_parser_normalizes_common_model_output_variants(self):
+        namespace = _load_keyboard_namespace()
+
+        groups = namespace["XDOParser"].parse("CTRL + ARROWRIGHT page down")
+
+        self.assertEqual(
+            _event_tuples(groups[0]),
+            [("ctrl", True), ("right", True), ("right", False), ("ctrl", False)],
+        )
+        self.assertEqual(
+            _event_tuples(groups[1]),
+            [("pagedown", True), ("pagedown", False)],
+        )
+
+    def test_canonicalizer_covers_common_modifier_and_navigation_aliases(self):
+        namespace = _load_keyboard_namespace()
+        canonicalize = namespace["_canonicalize_keyboard_key"]
+
+        self.assertEqual(canonicalize("Left-Control"), "ctrl")
+        self.assertEqual(canonicalize("Option"), "alt")
+        self.assertEqual(canonicalize("WinLeft"), "win")
+        self.assertEqual(canonicalize("PgDn"), "pagedown")
+        self.assertEqual(canonicalize("ARROWLEFT"), "left")
+        self.assertEqual(canonicalize("spacebar"), "space")
+
+    def test_execute_xdo_sequence_uses_canonical_keys_in_fallback_backend(self):
+        namespace = _load_keyboard_namespace()
+        recorded_calls = []
+
+        namespace["platform"] = types.SimpleNamespace(system=lambda: "Linux")
+        namespace["pyautogui"] = types.SimpleNamespace(
+            keyDown=lambda key: recorded_calls.append(("down", key)),
+            keyUp=lambda key: recorded_calls.append(("up", key)),
+        )
+
+        namespace["execute_xdo_sequence"]("Meta + arrow left PgDn")
+
+        self.assertEqual(
+            recorded_calls,
+            [
+                ("down", "win"),
+                ("down", "left"),
+                ("up", "left"),
+                ("up", "win"),
+                ("down", "pagedown"),
+                ("up", "pagedown"),
+            ],
+        )
+
+    def test_scan_code_path_accepts_aliases_after_canonicalization(self):
+        namespace = _load_keyboard_namespace()
+        recorded_calls = []
+
+        namespace["_win32_send_key"] = lambda scan_code, key_up=False: recorded_calls.append(
+            (scan_code, key_up)
+        )
+
+        namespace["_press_key_with_scancode"]("ARROWRIGHT")
+        namespace["_press_key_with_scancode"]("Page_Down", key_up=True)
+        namespace["_press_key_with_scancode"]("Left-Control")
+
+        self.assertEqual(
+            recorded_calls,
+            [
+                (0xE04D, False),
+                (0xE051, True),
+                (0x1D, False),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_keyboard_key_aliases.py
+++ b/tests/test_keyboard_key_aliases.py
@@ -134,6 +134,29 @@ class KeyboardAliasTests(unittest.TestCase):
             ],
         )
 
+    def test_scan_code_path_preserves_right_side_modifier_scan_codes(self):
+        namespace = _load_keyboard_namespace()
+        recorded_calls = []
+
+        namespace["_win32_send_key"] = lambda scan_code, key_up=False: recorded_calls.append(
+            (scan_code, key_up)
+        )
+
+        namespace["_press_key_with_scancode"]("rshift")
+        namespace["_press_key_with_scancode"]("Right-Control")
+        namespace["_press_key_with_scancode"]("right alt", key_up=True)
+        namespace["_press_key_with_scancode"]("RightWin")
+
+        self.assertEqual(
+            recorded_calls,
+            [
+                (0x36, False),
+                (0xE01D, False),
+                (0xE038, True),
+                (0xE05C, False),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core keyboard input parsing and Windows SendInput scan-code mapping, so regressions could break common hotkeys or modifier behavior across platforms.
> 
> **Overview**
> Improves keyboard sequence handling by **normalizing and canonicalizing common model-generated key names** (e.g., `arrow right`, `page down`, `meta/cmd`, left/right modifier variants) so both the XDO parser and execution backends accept a consistent set of keys.
> 
> Windows scan-code dispatch (`_press_key_with_scancode`) is updated to resolve modifier-side aliases (e.g., `Right-Control`, `right alt`) while preserving distinct right/left scan codes, and a new unit test suite validates parsing, canonicalization, PyAutoGUI fallback behavior, and scan-code mappings. Documentation and internal version strings are bumped to `0.0.41`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d477e856a2b63e6db2f451825e719c8d153c7e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->