### PR TITLE
Remediate CYB-100, CYB-101, CYB-102, and CYB-103: remove legacy start mode and enforce tunnel-only control API access

### DIFF
--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -65,14 +65,12 @@ pyinstaller \
 chmod +x dist/cyberdriver
 
 # Run it
-./dist/cyberdriver start --port 3000
-# or
 ./dist/cyberdriver join --secret YOUR_API_KEY
 ```
 
 ### Windows
 ```cmd
-dist\cyberdriver.exe start --port 3000
+dist\cyberdriver.exe join --secret YOUR_API_KEY
 ```
 
 ## Platform-Specific Notes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A comprehensive remote computer control tool with all major features for remote 
 ## Features
 
 ### Complete Feature Set
-- ✅ **HTTP API Server** - All endpoints for display, keyboard, and mouse control 
+- ✅ **HTTP API Server** - Local control server used behind the authenticated Cyberdesk tunnel
 - ✅ **WebSocket Tunnel** - Connect to remote control servers with proper protocol
 - ✅ **XDO Keyboard Input** - Support for complex key sequences like `ctrl+c ctrl+v`
 - ✅ **Screenshot Scaling** - Three modes: Exact, AspectFit, AspectFill
@@ -32,9 +32,10 @@ A comprehensive remote computer control tool with all major features for remote 
 - `POST /computer/input/mouse/move` - Move to position (smooth interpolation)
 - `POST /computer/input/mouse/click` - Click with optional press/release control
 
-#### Not Implemented (matching original)
-- File system endpoints (list, read, write)
-- Shell command execution (cmd, powershell)
+#### Protected Operational Routes
+- File system endpoints (`/computer/fs/*`) are available through authenticated tunnel requests only
+- PowerShell endpoints (`/computer/shell/powershell/*`) are available through authenticated tunnel requests only
+- Internal operational routes (`/internal/*`) are tunnel-only
 
 ## Installation
 
@@ -49,7 +50,7 @@ New-Item -ItemType Directory -Force -Path $toolDir
 
 # Download cyberdriver
 try {
-    Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.41/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe" -ErrorAction Stop
+    Invoke-WebRequest -Uri "https://github.com/cyberdesk-hq/cyberdriver/releases/download/v0.0.42/cyberdriver.exe" -OutFile "$toolDir\cyberdriver.exe" -ErrorAction Stop
 } catch {
     Write-Host "ERROR: Failed to download Cyberdriver. If Cyberdriver is already running, run 'cyberdriver stop' first. Otherwise, check your internet connection and try again." -ForegroundColor Red
     return
@@ -77,7 +78,7 @@ if (Test-Path "$toolDir\cyberdriver.exe") {
 
 ```bash
 # Choose version and target directory
-VERSION=0.0.41
+VERSION=0.0.42
 TOOL_DIR="$HOME/.cyberdriver"
 mkdir -p "$TOOL_DIR"
 
@@ -113,21 +114,17 @@ echo "- Screen Recording"
 
 1. Right-click on PowerShell and select "Run as Administrator"
 2. Navigate to your desired directory
-3. Run `cyberdriver start` or `cyberdriver join --secret YOUR_KEY`
+3. Run `cyberdriver join --secret YOUR_KEY`
 
 This ensures cyberdriver has the necessary permissions to interact with elevated applications. If you're only automating regular user-level applications, you can run cyberdriver normally without admin privileges.
 
-Cyberdriver can then be started with:
-
-```bash
-cyberdriver start
-```
-
-Or subscribed for remote use via Cyberdesk cloud:
+Cyberdriver is started by connecting it to Cyberdesk:
 
 ```bash
 cyberdriver join --secret SK-YOUR-SECRET-KEY
 ```
+
+The legacy standalone `cyberdriver start` mode has been removed. Privileged local routes are only accessible through the authenticated `cyberdriver join` tunnel path.
 
 ## Agent Protection (Preventing Accidental Termination)
 
@@ -177,23 +174,9 @@ Cyberdriver can update itself remotely, even while running. This is useful for:
 - Keeping all your machines on the latest version without manual intervention
 - Zero-downtime updates (machine is only offline for ~10 seconds)
 
-### Via execute_terminal_command
-
-Run this PowerShell command through `execute_terminal_command`:
-
-```powershell
-Invoke-RestMethod -Method Post -Uri "http://localhost:3000/internal/update" -ContentType "application/json" -Body '{"version":"latest","restart":true}'
-```
-
-Or specify a specific version:
-
-```powershell
-Invoke-RestMethod -Method Post -Uri "http://localhost:3000/internal/update" -ContentType "application/json" -Body '{"version":"0.0.41","restart":true}'
-```
-
 ### Via Cyberdesk API
 
-You can also call the update endpoint directly through the Cyberdesk API:
+Trigger self-update through an authenticated Cyberdesk workflow or API call:
 
 ```bash
 curl -X POST "https://api.cyberdesk.io/v1/computer/{machine_id}/internal/update" \
@@ -201,6 +184,8 @@ curl -X POST "https://api.cyberdesk.io/v1/computer/{machine_id}/internal/update"
   -H "Content-Type: application/json" \
   -d '{"version": "latest", "restart": true}'
 ```
+
+Direct localhost calls to `/internal/update` are intentionally blocked. The route is available only through the authenticated tunnel path.
 
 ### How It Works
 
@@ -239,11 +224,6 @@ pip install -r requirements.txt
 ```
 
 ## Usage
-
-### Start Local Server
-```bash
-python cyberdriver.py start --port 3000
-```
 
 ### Join Remote Control Server
 ```bash
@@ -366,7 +346,7 @@ The executable will be in the `dist/` directory.
 ## Key Features
 
 1. **Cross-platform cursor overlay** - Uses tkinter on Windows, prints warning on other platforms
-2. **Filesystem/Shell endpoints** - Return 501 Not Implemented
+2. **Filesystem/Shell endpoints** - Protected behind the authenticated tunnel path
 3. **Smooth mouse movement** - Configurable steps and duration
 4. **Enhanced error handling** - Better error messages and recovery
 

--- a/VANTA_PENETRATION_TEST_REMEDIATION_EVIDENCE_CYB_100_103.md
+++ b/VANTA_PENETRATION_TEST_REMEDIATION_EVIDENCE_CYB_100_103.md
@@ -1,0 +1,181 @@
+# Penetration Test Remediation
+
+## Document Purpose
+This document records the remediation approach for four findings identified in the most recent Oneleet penetration test for Cyberdriver. It is intended to support Vanta evidence submission and to serve as a centralized remediation record for implementation, follow-up testing, configuration changes, patch management, and management sign-off.
+
+Prepared By: `Cyberdesk / Alan Duong`  
+Prepared On: `2026-04-09`  
+System: `Cyberdriver`  
+Assessment Source: `Oneleet penetration test`  
+Affected Component: `Local control API and privileged control routes`  
+Remediation Release Version: `0.0.42`  
+Status: `Implemented in source; attach release and deployment evidence`
+
+## Implementation Guidance
+1. Establish a centralized remediation record for each finding while documenting the shared architectural fix that addresses the group of issues.
+2. Capture supporting artifacts for follow-up testing, release/version tracking, configuration changes, and patch management once implementation is complete.
+3. Obtain engineering and security review, then retain the final approved package in the compliance evidence repository for future audits.
+
+## Remediation Summary
+The four findings below stem from the same underlying condition: privileged local-control routes were reachable without a consistent local access gate, and the legacy `cyberdriver start` command exposed the control API as a standalone listener.
+
+The planned remediation is:
+- Remove the legacy `cyberdriver start` feature so Cyberdriver no longer runs the control API as a directly exposed standalone service.
+- Restrict privileged local routes to the authenticated `cyberdriver join` tunnel path by reusing the existing in-process tunnel token mechanism already present in Cyberdriver.
+- Preserve the mission-critical `cyberdriver join` workflow so authorized tunnel-forwarded requests continue to function normally.
+- Update documentation and validation assets to reflect the remediated design.
+- Bump the Cyberdriver version after remediation is complete so the release can be tracked in deployment records and evidence submissions.
+
+## Remediation Architecture
+The remediated design keeps the local FastAPI server only as an internal implementation detail of the `join` flow. Under this model:
+- Cyberdriver authenticates to the Cyberdesk control plane using the existing `join` secret and tunnel flow.
+- Cyberdriver forwards authenticated tunnel requests into the local loopback API.
+- Cyberdriver adds an internal per-process trust header to privileged forwarded requests.
+- Privileged routes reject direct local requests that do not include the trusted internal header.
+- The legacy standalone `start` path is removed so there is no direct network-exposed control listener to target.
+
+No Cyberdesk server-side protocol changes are required for this remediation approach. The access control change is implemented within Cyberdriver on the local forwarding hop.
+
+## Detailed Remediation By Finding
+
+### CYB-100
+**Title:** `[CD-001] Oneleet Pentest Finding: Unauthenticated Network-Exposed Control API`
+
+**Finding Summary**  
+The penetration test identified that Cyberdriver exposed a privileged local control API on all network interfaces and did not consistently require authentication or authorization for high-risk desktop control routes.
+
+**Root Cause**  
+The legacy `cyberdriver start` path exposed the FastAPI service as a standalone listener, and privileged `/computer/*` routes relied on network reachability rather than a dedicated local trust boundary.
+
+**Remediation**  
+- Remove the legacy `cyberdriver start` feature so the standalone network-exposed listener no longer exists.
+- Restrict privileged local routes to the authenticated tunnel path by applying a shared tunnel-only guard.
+- Continue serving the `join` path on loopback only, with the trusted internal token attached by Cyberdriver when forwarding legitimate tunnel traffic.
+
+**Why This Remediates The Finding**  
+This change removes the direct network exposure condition and ensures privileged control routes are no longer callable by an unauthenticated network-reachable attacker.
+
+**Validation / Evidence To Attach**  
+- Code change showing removal of `start`
+- Validation that `join` still functions normally
+- Validation that direct unauthenticated calls to privileged routes are rejected
+- Release record showing patched Cyberdriver version
+
+**Status**  
+`Implemented in source; attach release and validation evidence`
+
+### CYB-101
+**Title:** `[CD-002] Oneleet Pentest Finding: Remote Code Execution via Unauthenticated PowerShell Exec Endpoint`
+
+**Finding Summary**  
+The penetration test identified that `/computer/shell/powershell/exec` accepted command content and executed it without a local authorization gate, creating an unauthenticated remote code execution path if the API port was reachable.
+
+**Root Cause**  
+The PowerShell execution endpoint is an intentionally privileged product capability, but it was reachable through the same insufficiently protected local control surface described in CYB-100.
+
+**Remediation**  
+- Place `/computer/shell/powershell/*` behind the same tunnel-only authorization guard used for privileged local routes.
+- Remove the legacy standalone `start` listener so the endpoint is not exposed as a directly reachable network service.
+- Preserve PowerShell execution only for authenticated, authorized tunnel-mediated control flows.
+
+**Why This Remediates The Finding**  
+The issue identified by the penetration test was unauthenticated command execution through a reachable API surface. After remediation, PowerShell execution remains an intentional administrative capability but is no longer exposed to unauthenticated direct callers.
+
+**Validation / Evidence To Attach**  
+- Negative test showing direct local request rejection without the trusted internal header
+- Positive test showing tunnel-forwarded execution still works as designed
+- Updated release/version record
+
+**Status**  
+`Implemented in source; attach release and validation evidence`
+
+### CYB-102
+**Title:** `[CD-003] Oneleet Pentest Finding: Arbitrary File Read/Write via Unauthenticated File-System Endpoints`
+
+**Finding Summary**  
+The penetration test identified that `/computer/fs/read` and `/computer/fs/write` exposed broad file system access without a local authorization gate, allowing unauthorized file read/write behavior if the API port was reachable.
+
+**Root Cause**  
+The filesystem endpoints are intentionally privileged operational capabilities, but they were reachable through the same insufficiently protected local control surface described in CYB-100.
+
+**Remediation**  
+- Place `/computer/fs/*` behind the shared tunnel-only authorization guard.
+- Remove the legacy standalone `start` listener so these routes are not directly reachable on a network-exposed service.
+- Preserve file operations only for authenticated, authorized tunnel-mediated control flows.
+
+**Why This Remediates The Finding**  
+The issue identified by the penetration test was arbitrary file access through unauthenticated endpoint exposure. After remediation, the file-system routes remain privileged internal capabilities and are no longer available to unauthenticated direct callers.
+
+**Validation / Evidence To Attach**  
+- Negative test showing direct local request rejection without the trusted internal header
+- Positive test showing tunnel-forwarded file operations still work as designed
+- Updated release/version record
+
+**Status**  
+`Implemented in source; attach release and validation evidence`
+
+### CYB-103
+**Title:** `[CD-004] Oneleet Pentest Finding: Unauthenticated Self-Update Trigger Enables Remote DoS/Code Replacement Flow`
+
+**Finding Summary**  
+The penetration test identified that `/internal/update` could trigger a self-update flow without a dedicated local authorization gate, enabling unauthorized operational control if the API port was reachable.
+
+**Root Cause**  
+The self-update route is an intentionally privileged operational capability, but it was reachable through the same insufficiently protected local control surface described in CYB-100.
+
+**Remediation**  
+- Place `/internal/update` and related privileged operational routes behind the shared tunnel-only authorization guard.
+- Remove the legacy standalone `start` listener so the self-update route is not directly reachable on a network-exposed service.
+- Preserve self-update only for authenticated, authorized tunnel-mediated control flows.
+
+**Why This Remediates The Finding**  
+The issue identified by the penetration test was the unauthenticated triggering of a privileged update flow. After remediation, the update route remains an intentional administrative capability and is no longer available to unauthenticated direct callers.
+
+**Validation / Evidence To Attach**  
+- Negative test showing direct local request rejection without the trusted internal header
+- Positive test showing authenticated tunnel-mediated update flow still works as designed, or controlled verification in a safe test environment
+- Updated release/version record
+
+**Status**  
+`Implemented in source; attach release and validation evidence`
+
+## Follow-Up Testing And Verification
+Attach or reference the following after implementation:
+- Test results showing the legacy `cyberdriver start` path has been removed
+- Test results showing `cyberdriver join` still functions normally
+- Test results showing privileged routes reject direct requests without the trusted internal token
+- Test results showing privileged tunnel-forwarded requests succeed as expected
+- Any relevant logs, screenshots, or QA notes that confirm the patched behavior
+
+Validation Owner: `[Insert name]`  
+Validation Date: `[Insert date]`
+
+## Configuration Change Record
+Configuration / release records to attach:
+- Source change reference: `[Insert PR, branch, or change request ID]`
+- Deployment record: `[Insert deployment date / environment / approver]`
+- Remediated Cyberdriver version: `0.0.42`
+- Documentation updates completed: `[Yes / No]`
+
+## Patch Management Record
+Patch management evidence to attach:
+- Release version containing the remediation: `0.0.42`
+- Artifact or package identifier: `[Insert package / build reference]`
+- Rollout date: `[Insert date]`
+- Rollout scope: `[Insert affected environments or customer scope]`
+- Rollback plan or release note reference: `[Insert reference]`
+
+## Management Sign-Off
+Engineering Owner: `[Name, title, date]`  
+Security Reviewer: `[Name, title, date]`  
+Management Approval: `[Name, title, date]`
+
+## Evidence Collection Checklist
+- Remediation documentation detailing the steps taken to address each identified issue
+- Follow-up testing reports confirming the effectiveness of the remediation
+- Management sign-off acknowledging completion and adequacy of the remediation
+- Configuration change records related to the identified issues
+- Patch management records showing the remediated release version and deployment history
+
+## Final Notes
+This remediation package addresses four separately tracked findings through one controlled architectural change. The intent of the change is not to remove privileged Cyberdriver capabilities from authorized use, but to ensure those capabilities are accessible only through the authenticated Cyberdesk tunnel path and are no longer exposed through a legacy standalone listener.

--- a/build_executable.py
+++ b/build_executable.py
@@ -57,7 +57,7 @@ def main():
             size = os.path.getsize(executable_path) / (1024 * 1024)
             print(f"\nExecutable created: {executable_path}")
             print(f"Size: {size:.1f} MB")
-            print("\nTo run: ./dist/cyberdriver start --port 3000")
+            print("\nTo run: ./dist/cyberdriver join --secret YOUR_API_KEY")
         else:
             print(f"\n❌ Executable not found at {executable_path}")
             

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -34,7 +34,6 @@ Install dependencies:
     pip install fastapi uvicorn[standard] websockets httpx mss pyautogui pillow numpy
 
 Usage:
-    cyberdriver start [--port 3000]
     cyberdriver join --secret YOUR_API_KEY [--host example.com] [--port 443]
 """
 
@@ -1490,7 +1489,7 @@ async def connect_with_headers(uri, headers_dict):
 CONFIG_DIR = ".cyberdriver"
 CONFIG_FILE = "config.json"
 PID_FILE = "cyberdriver.pid.json"
-VERSION = "0.0.41"
+VERSION = "0.0.42"
 
 @dataclass
 class Config:
@@ -2541,6 +2540,16 @@ async def disable_buffering(request, call_next):
     method = request.method
     path = request.url.path
     request_start = time.perf_counter()
+    if _is_tunnel_protected_path(path) and not _is_request_from_active_tunnel(request):
+        response = JSONResponse(
+            status_code=403,
+            content={"error": "Forbidden: tunnel-only endpoint"},
+        )
+        duration_ms = (time.perf_counter() - request_start) * 1000
+        print(f"{method} {path} -> {response.status_code} ({duration_ms:.1f}ms)")
+        response.headers["X-Accel-Buffering"] = "no"
+        response.headers["Cache-Control"] = "no-cache"
+        return response
     try:
         response = await call_next(request)
     except Exception:
@@ -2629,6 +2638,24 @@ async def post_remote_keepalive_disable():
 
 
 TUNNEL_INTERNAL_REQUEST_HEADER = "x-cyberdesk-tunnel-token"
+TUNNEL_PROTECTED_ROUTE_PREFIXES = ("/computer/", "/internal/")
+
+
+def _is_tunnel_protected_path(path: str) -> bool:
+    """Return True if the route must only be reachable via the authenticated tunnel."""
+    if not isinstance(path, str):
+        return False
+    return path.startswith(TUNNEL_PROTECTED_ROUTE_PREFIXES)
+
+
+def _build_local_forward_headers(
+    headers: Any, path: str, internal_request_token: Optional[str]
+) -> Dict[str, Any]:
+    """Clone request headers and attach the internal tunnel token when required."""
+    request_headers = dict(headers) if isinstance(headers, dict) else {}
+    if internal_request_token and _is_tunnel_protected_path(path):
+        request_headers[TUNNEL_INTERNAL_REQUEST_HEADER] = internal_request_token
+    return request_headers
 
 
 def _is_request_from_active_tunnel(request: Request) -> bool:
@@ -2650,11 +2677,8 @@ async def post_shutdown(request: Request):
     Returns immediately, then exits the process shortly after the response is sent.
     """
     try:
-        if not _is_request_from_active_tunnel(request):
-            raise HTTPException(status_code=403, detail="Forbidden: tunnel-only endpoint")
-
-        # Parse request JSON only after auth so unauthenticated malformed payloads
-        # cannot bypass tunnel-only checks via FastAPI body validation.
+        # Parse request JSON after the middleware-auth check so malformed payloads
+        # cannot bypass tunnel-only access control via FastAPI body validation.
         payload: Optional[Dict[str, Any]] = None
         try:
             raw_payload = await request.body()
@@ -2890,7 +2914,7 @@ async def _resolve_latest_version() -> Optional[str]:
 
 
 class UpdateRequest(BaseModel):
-    version: str = Field(default="latest", description="Target version (e.g. '0.0.41') or 'latest'")
+    version: str = Field(default="latest", description="Target version (e.g. '0.0.42') or 'latest'")
     restart: bool = Field(default=True, description="Whether to restart Cyberdriver after update")
 
 
@@ -2907,16 +2931,16 @@ async def post_update(payload: UpdateRequest = UpdateRequest()):
     
     Request body (optional):
     {
-        "version": "0.0.41",  // Target version (without 'v' prefix), or "latest" (default)
+        "version": "0.0.42",  // Target version (without 'v' prefix), or "latest" (default)
         "restart": true       // Whether to restart after update (default: true)
     }
     
     Returns:
     {
         "status": "update_initiated",
-        "current_version": "0.0.41",
-        "target_version": "0.0.41",
-        "message": "Updating to v0.0.41. Cyberdriver will restart automatically."
+        "current_version": "0.0.42",
+        "target_version": "0.0.42",
+        "message": "Updating to v0.0.42. Cyberdriver will restart automatically."
     }
     """
     if platform.system() != "Windows":
@@ -5293,9 +5317,9 @@ class TunnelClient:
         path = meta["path"]
         query = meta.get("query", "")
         headers = meta.get("headers", {})
-        request_headers = dict(headers) if isinstance(headers, dict) else {}
-        if self.internal_request_token and path == "/internal/shutdown":
-            request_headers[TUNNEL_INTERNAL_REQUEST_HEADER] = self.internal_request_token
+        request_headers = _build_local_forward_headers(
+            headers, path, self.internal_request_token
+        )
         
         # Check for idempotency key (case-insensitive header lookup)
         idempotency_key: Optional[str] = None
@@ -5516,12 +5540,6 @@ class TunnelClient:
 # -----------------------------------------------------------------------------
 # Main entry point
 # -----------------------------------------------------------------------------
-
-def run_server(port: int):
-    """Run the FastAPI server."""
-    # Keep request logging single-sourced via Cyberdriver's own timestamped print lines.
-    uvicorn.run(app, host="0.0.0.0", port=port, access_log=False)
-
 
 async def run_server_async(port: int):
     """Run the FastAPI server asynchronously."""
@@ -6707,14 +6725,6 @@ def main():
     
     subparsers = parser.add_subparsers(dest="command", metavar="")
     
-    # start command
-    start_parser = subparsers.add_parser(
-        "start", 
-        help="Start local server",
-        description="Start Cyberdriver API server locally for testing"
-    )
-    start_parser.add_argument("--port", type=int, default=3000, help="Port (default: 3000)")
-    
     # join command
     join_parser = subparsers.add_parser(
         "join", 
@@ -7035,28 +7045,7 @@ def main():
         print("✓ Experimental space mode enabled (using VK code instead of scan code)")
     
     try:
-        if args.command == "start":
-            actual_port = find_available_port("0.0.0.0", args.port)
-            if actual_port is None:
-                print(f"Error: Could not find an available port starting from {args.port}.")
-                sys.exit(1)
-
-            write_pid_info({"command": "start", "local_port": actual_port})
-            
-            # Try to print with checkmark
-            if platform.system() == "Windows":
-                try:
-                    import ctypes
-                    kernel32 = ctypes.windll.kernel32
-                    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
-                    print(f"✓ Cyberdriver server starting on http://0.0.0.0:{actual_port}")
-                except:
-                    print(f"√ Cyberdriver server starting on http://0.0.0.0:{actual_port}")
-            else:
-                print(f"✓ Cyberdriver server starting on http://0.0.0.0:{actual_port} ")
-            run_server(actual_port)
-        
-        elif args.command == "coords":
+        if args.command == "coords":
             run_coords_capture()
 
         elif args.command == "join":

--- a/tests/test_buffering_fix.py
+++ b/tests/test_buffering_fix.py
@@ -124,7 +124,9 @@ async def main():
     print("Cyberdriver Buffering Test")
     print("=" * 60)
     print(f"Testing server at: {BASE_URL}")
-    print("Make sure cyberdriver is running with: python cyberdriver.py start")
+    print("Legacy manual diagnostic script.")
+    print("Privileged localhost routes are now tunnel-only and direct local access is blocked.")
+    print("Use authenticated tunnel integration testing for supported verification.")
     print("=" * 60)
     
     # Give user time to see the message

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,133 +1,165 @@
-#!/usr/bin/env python3
-"""
-Test script to demonstrate Cyberdriver enhanced features.
-Run this after starting the server with: python cyberdriver.py start --port 3000
-"""
-
-import requests
-import json
+import ast
+import asyncio
+import copy
+import secrets
 import time
+import types
+import unittest
+from pathlib import Path
+from typing import Any, Dict, Optional
 
-BASE_URL = "http://localhost:3000"
-
-def test_screenshot_scaling():
-    """Test different screenshot scaling modes."""
-    print("Testing screenshot scaling modes...")
-    
-    # Test exact scaling
-    response = requests.get(f"{BASE_URL}/computer/display/screenshot", 
-                          params={"width": 800, "height": 600, "mode": "exact"})
-    print(f"  Exact mode (800x600): {response.status_code}, size: {len(response.content)} bytes")
-    
-    # Test aspect fit
-    response = requests.get(f"{BASE_URL}/computer/display/screenshot", 
-                          params={"width": 1024, "height": 768, "mode": "aspect_fit"})
-    print(f"  Aspect fit mode: {response.status_code}, size: {len(response.content)} bytes")
-    
-    # Test aspect fill
-    response = requests.get(f"{BASE_URL}/computer/display/screenshot", 
-                          params={"width": 1920, "height": 1080, "mode": "aspect_fill"})
-    print(f"  Aspect fill mode: {response.status_code}, size: {len(response.content)} bytes")
+from fastapi.responses import JSONResponse
 
 
-def test_xdo_keyboard():
-    """Test XDO keyboard sequences."""
-    print("\nTesting XDO keyboard input...")
-    
-    # Test simple key combo
-    response = requests.post(f"{BASE_URL}/computer/input/keyboard/key",
-                           json={"text": "ctrl+a"})
-    print(f"  ctrl+a: {response.status_code}")
-    time.sleep(0.5)
-    
-    # Test complex sequence
-    response = requests.post(f"{BASE_URL}/computer/input/keyboard/key",
-                           json={"text": "ctrl+shift+home"})
-    print(f"  ctrl+shift+home: {response.status_code}")
-    time.sleep(0.5)
-    
-    # Test multiple commands
-    response = requests.post(f"{BASE_URL}/computer/input/keyboard/key",
-                           json={"text": "alt+tab alt+tab"})
-    print(f"  alt+tab alt+tab: {response.status_code}")
+SOURCE_PATH = Path(__file__).resolve().parents[1] / "cyberdriver.py"
+
+TARGET_ASSIGNMENTS = {
+    "TUNNEL_INTERNAL_REQUEST_HEADER",
+    "TUNNEL_PROTECTED_ROUTE_PREFIXES",
+}
+TARGET_FUNCTIONS = {
+    "_is_tunnel_protected_path",
+    "_build_local_forward_headers",
+    "_is_request_from_active_tunnel",
+    "disable_buffering",
+}
 
 
-def test_mouse_features():
-    """Test enhanced mouse features."""
-    print("\nTesting mouse features...")
-    
-    # Get current position
-    response = requests.get(f"{BASE_URL}/computer/input/mouse/position")
-    pos = response.json()
-    print(f"  Current position: {pos}")
-    
-    # Test smooth movement
-    print("  Testing smooth movement...")
-    response = requests.post(f"{BASE_URL}/computer/input/mouse/move",
-                           json={"x": 500, "y": 500})
-    print(f"    Move to (500,500): {response.status_code}")
-    time.sleep(1)
-    
-    # Test mouse down/up separately
-    print("  Testing separate press/release...")
-    response = requests.post(f"{BASE_URL}/computer/input/mouse/click",
-                           json={"button": "left", "down": True})
-    print(f"    Mouse down: {response.status_code}")
-    time.sleep(0.5)
-    
-    response = requests.post(f"{BASE_URL}/computer/input/mouse/click",
-                           json={"button": "left", "down": False})
-    print(f"    Mouse up: {response.status_code}")
+def _load_route_protection_namespace():
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    module = ast.parse(source, filename=str(SOURCE_PATH))
+    selected_nodes = []
+
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            target_names = {
+                target.id
+                for target in node.targets
+                if isinstance(target, ast.Name)
+            }
+            if target_names & TARGET_ASSIGNMENTS:
+                selected_nodes.append(copy.deepcopy(node))
+        elif isinstance(node, ast.FunctionDef) and node.name in TARGET_FUNCTIONS:
+            node_copy = copy.deepcopy(node)
+            node_copy.decorator_list = []
+            selected_nodes.append(node_copy)
+        elif isinstance(node, ast.AsyncFunctionDef) and node.name in TARGET_FUNCTIONS:
+            node_copy = copy.deepcopy(node)
+            node_copy.decorator_list = []
+            selected_nodes.append(node_copy)
+
+    fake_app = types.SimpleNamespace(
+        state=types.SimpleNamespace(tunnel_internal_token="test-internal-token")
+    )
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    namespace = {
+        "Any": Any,
+        "Dict": Dict,
+        "Optional": Optional,
+        "JSONResponse": JSONResponse,
+        "Request": object,
+        "app": fake_app,
+        "print": lambda *args, **kwargs: None,
+        "secrets": secrets,
+        "time": time,
+    }
+    exec(compile(extracted_module, str(SOURCE_PATH), "exec"), namespace)
+    return namespace
 
 
-def test_not_implemented():
-    """Test that filesystem and shell endpoints return 501."""
-    print("\nTesting not-implemented endpoints...")
-    
-    # File system
-    response = requests.get(f"{BASE_URL}/computer/fs/list", params={"path": "."})
-    print(f"  fs/list: {response.status_code} (expected 501)")
-    
-    response = requests.get(f"{BASE_URL}/computer/fs/read", params={"path": "test.txt"})
-    print(f"  fs/read: {response.status_code} (expected 501)")
-    
-    response = requests.post(f"{BASE_URL}/computer/fs/write", 
-                           json={"path": "test.txt", "content": "test"})
-    print(f"  fs/write: {response.status_code} (expected 501)")
-    
-    # Shell
-    response = requests.post(f"{BASE_URL}/computer/shell/cmd/exec",
-                           json={"command": "echo test"})
-    print(f"  shell/cmd/exec: {response.status_code} (expected 501)")
-    
-    response = requests.post(f"{BASE_URL}/computer/shell/powershell/exec",
-                           json={"command": "echo test"})
-    print(f"  shell/powershell/exec: {response.status_code} (expected 501)")
+class _FakeRequest:
+    def __init__(self, path: str, headers: Optional[Dict[str, str]] = None, method: str = "GET"):
+        self.method = method
+        self.headers = headers or {}
+        self.url = types.SimpleNamespace(path=path)
 
 
-def main():
-    """Run all tests."""
-    print("Cyberdriver Feature Tests")
-    print("===========================")
-    
-    try:
-        # Test connection
-        response = requests.get(f"{BASE_URL}/computer/display/dimensions")
-        response.raise_for_status()
-        dims = response.json()
-        print(f"Connected! Screen dimensions: {dims['width']}x{dims['height']}")
-    except Exception as e:
-        print(f"Failed to connect to server: {e}")
-        print("Make sure server is running: python cyberdriver.py start --port 3000")
-        return
-    
-    test_screenshot_scaling()
-    test_xdo_keyboard()
-    test_mouse_features()
-    test_not_implemented()
-    
-    print("\nAll tests completed!")
+class TunnelProtectionTests(unittest.TestCase):
+    def test_protected_path_helper_matches_expected_prefixes(self):
+        namespace = _load_route_protection_namespace()
+
+        self.assertTrue(namespace["_is_tunnel_protected_path"]("/computer/display/screenshot"))
+        self.assertTrue(namespace["_is_tunnel_protected_path"]("/internal/update"))
+        self.assertFalse(namespace["_is_tunnel_protected_path"]("/docs"))
+        self.assertFalse(namespace["_is_tunnel_protected_path"]("/tunnel/ws"))
+
+    def test_forward_headers_add_internal_token_for_protected_routes(self):
+        namespace = _load_route_protection_namespace()
+
+        headers = namespace["_build_local_forward_headers"](
+            {"x-idempotency-key": "abc123"},
+            "/computer/fs/read",
+            "secret-token",
+        )
+
+        self.assertEqual(headers["x-idempotency-key"], "abc123")
+        self.assertEqual(
+            headers[namespace["TUNNEL_INTERNAL_REQUEST_HEADER"]],
+            "secret-token",
+        )
+
+    def test_forward_headers_leave_unprotected_routes_unchanged(self):
+        namespace = _load_route_protection_namespace()
+
+        headers = namespace["_build_local_forward_headers"](
+            {"x-idempotency-key": "abc123"},
+            "/docs",
+            "secret-token",
+        )
+
+        self.assertEqual(headers, {"x-idempotency-key": "abc123"})
+
+    def test_middleware_blocks_direct_requests_without_tunnel_token(self):
+        namespace = _load_route_protection_namespace()
+        call_next_called = False
+
+        async def call_next(_request):
+            nonlocal call_next_called
+            call_next_called = True
+            return JSONResponse(status_code=200, content={"ok": True})
+
+        response = asyncio.run(
+            namespace["disable_buffering"](
+                _FakeRequest("/computer/input/mouse/click"),
+                call_next,
+            )
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(call_next_called)
+
+    def test_middleware_allows_requests_with_valid_tunnel_token(self):
+        namespace = _load_route_protection_namespace()
+        call_next_called = False
+        header_name = namespace["TUNNEL_INTERNAL_REQUEST_HEADER"]
+
+        async def call_next(_request):
+            nonlocal call_next_called
+            call_next_called = True
+            return JSONResponse(status_code=200, content={"ok": True})
+
+        response = asyncio.run(
+            namespace["disable_buffering"](
+                _FakeRequest(
+                    "/internal/update",
+                    headers={header_name: "test-internal-token"},
+                    method="POST",
+                ),
+                call_next,
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(call_next_called)
+
+    def test_source_no_longer_contains_legacy_start_command(self):
+        source = SOURCE_PATH.read_text(encoding="utf-8")
+
+        self.assertNotIn('start_parser = subparsers.add_parser(', source)
+        self.assertNotIn('if args.command == "start":', source)
+        self.assertNotIn("cyberdriver start [--port 3000]", source)
+        self.assertNotIn("0.0.0.0", source)
 
 
 if __name__ == "__main__":
-    main() 
+    unittest.main()

--- a/tests/test_smooth_mouse.py
+++ b/tests/test_smooth_mouse.py
@@ -75,7 +75,9 @@ or similar low-level APIs.
 
 
 if __name__ == "__main__":
-    print("Make sure the server is running: python cyberdriver.py start --port 3000")
+    print("Legacy manual diagnostic script.")
+    print("Privileged localhost routes are now tunnel-only and direct local access is blocked.")
+    print("Use authenticated tunnel integration testing for supported verification.")
     print()
     
     try:


### PR DESCRIPTION
Auth for tunnel-only access for privileged routes

- Updated usage instructions to reflect the removal of the 'start' command, replacing it with 'join --secret YOUR_API_KEY'.
- Enhanced security by restricting access to privileged local routes, ensuring they are only reachable through the authenticated tunnel.
- Bumped version to 0.0.42 to signify these changes.
- Added documentation and tests to validate the new access control mechanisms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request access control and removes the `start` command, which is security-sensitive and could break any workflows relying on direct localhost/API access or the old standalone server mode.
> 
> **Overview**
> Cyberdriver no longer supports the legacy standalone `cyberdriver start` mode; only `cyberdriver join` remains for running the control plane connection and local API.
> 
> Privileged routes are now **tunnel-only**: a middleware blocks direct requests to `(/computer/*, /internal/*)` unless they include the in-process `x-cyberdesk-tunnel-token`, and tunnel forwarding now attaches this token via `_build_local_forward_headers`.
> 
> Docs/scripts/tests are updated to reflect the new model (including blocking direct `/internal/update` calls), a new Vanta remediation evidence doc is added, and the release version is bumped to `0.0.42`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d099fc68a8e6bb8a596f2529989c355482c623b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->