### PR TITLE
v0.0.44: Add machine naming support to join with validation, header propagation, and improved retry UX, fix Linux bug with display

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Press Esc when done. You can right-click multiple times to try different locatio
 By default, Cyberdesk auto-generates an internal id for each machine but leaves the display `name` blank. You can set a human-readable name at join time with `--name`:
 
 ```bash
-cyberdriver join --secret YOUR_API_KEY --name "beacon-vm-12"
+cyberdriver join --secret YOUR_API_KEY --name "your-vm-12"
 ```
 
 The name is sent to Cyberdesk as the `X-CYBERDRIVER-NAME` HTTP header on the WebSocket handshake and stored on the Machine row. Names must be printable ASCII, max 128 chars (no control characters or non-ASCII).

--- a/README.md
+++ b/README.md
@@ -380,6 +380,32 @@ Use with keepalive:
 
 Press Esc when done. You can right-click multiple times to try different locations. Regular left-clicks work normally and won't be captured. On trackpad, use two-finger click/tap for right-click.
 
+## Naming Machines
+
+By default, Cyberdesk auto-generates an internal id for each machine but leaves the display `name` blank. You can set a human-readable name at join time with `--name`:
+
+```bash
+cyberdriver join --secret YOUR_API_KEY --name "beacon-vm-12"
+```
+
+The name is sent to Cyberdesk as the `X-CYBERDRIVER-NAME` HTTP header on the WebSocket handshake and stored on the Machine row. Names must be printable ASCII, max 128 chars (no control characters or non-ASCII).
+
+### Use case: parallel provisioning
+
+When you spin up many VMs at once from the same image (AMI, snapshot, golden VM, etc.), each cyberdriver generates its own random fingerprint, so machines are correctly distinct in the dashboard - but they all have `name: null` by default, which makes them indistinguishable to your provisioning code. Pass `--name` from your start script with a value your code already knows:
+
+```bash
+# Example: AWS user-data that names each VM after its instance id
+INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+cyberdriver join --secret "$API_KEY" --name "$INSTANCE_ID"
+```
+
+Then look up the machine via the Cyberdesk API by name. To make lookup deterministic, ensure the names you supply are unique within your organization (e.g. include a UUID, instance id, or batch+index).
+
+### Renaming later
+
+Names can also be changed from the Cyberdesk dashboard. If you want a stable handle for your own systems, store the Cyberdesk machine `id` after the first lookup and key your records on that.
+
 ## Configuration
 
 Configuration is stored in:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -7624,7 +7624,7 @@ def main():
             sanitized_name = sanitize_machine_name(raw_name)
             if raw_name is not None and sanitized_name is None:
                 print(
-                    "Warning: --name value was empty or contained control characters; "
+                    "Warning: --name value was empty or contained non-ASCII/control characters; "
                     "ignoring. Cyberdesk will assign a default name."
                 )
             elif sanitized_name is not None:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -1800,6 +1800,35 @@ class Config:
         return cls(version=data["version"], fingerprint=data["fingerprint"])
 
 
+# Maximum length for a user-supplied machine name. Kept well under any
+# reasonable HTTP header size limit so we don't risk WS handshake rejection.
+MACHINE_NAME_MAX_LEN = 128
+
+
+def sanitize_machine_name(raw: Optional[str]) -> Optional[str]:
+    """Validate and clean a user-supplied --name value before sending it as a header.
+
+    Returns the cleaned name, or None if the input is empty/unset/invalid. We
+    strip surrounding whitespace, restrict to printable ASCII (HTTP headers
+    travel as latin-1 in the WS handshake and some proxies/CDNs reject
+    non-ASCII), reject control characters (CR/LF would allow header injection),
+    and cap the length. Customers wanting fancier display names can rename the
+    machine from the Cyberdesk dashboard after registration.
+    """
+    if raw is None:
+        return None
+    name = raw.strip()
+    if not name:
+        return None
+    # Printable ASCII only (0x20 space through 0x7E tilde). This rejects CR/LF,
+    # tabs, NULs, and any unicode beyond ASCII.
+    if not all(0x20 <= ord(ch) <= 0x7E for ch in name):
+        return None
+    if len(name) > MACHINE_NAME_MAX_LEN:
+        name = name[:MACHINE_NAME_MAX_LEN]
+    return name
+
+
 def get_config_dir() -> pathlib.Path:
     """Get the configuration directory path."""
     if platform.system() == "Windows":
@@ -5190,7 +5219,7 @@ class TunnelClient:
     IDEMPOTENCY_CACHE_TTL = 60.0  # Seconds to keep cached responses
     IDEMPOTENCY_CACHE_MAX_SIZE = 1000  # Maximum number of cached responses
     
-    def __init__(self, host: str, port: int, secret: str, target_port: int, config: Config, keepalive_manager: Optional["KeepAliveManager"] = None, remote_keepalive_for_main_id: Optional[str] = None, internal_request_token: Optional[str] = None):
+    def __init__(self, host: str, port: int, secret: str, target_port: int, config: Config, keepalive_manager: Optional["KeepAliveManager"] = None, remote_keepalive_for_main_id: Optional[str] = None, internal_request_token: Optional[str] = None, machine_name: Optional[str] = None):
         self.host = host
         self.port = port
         self.secret = secret
@@ -5203,6 +5232,7 @@ class TunnelClient:
         self.keepalive_manager = keepalive_manager
         self.remote_keepalive_for_main_id = remote_keepalive_for_main_id
         self.internal_request_token = internal_request_token
+        self.machine_name = machine_name
         
         # Idempotency cache: key -> (timestamp, response)
         # Used to prevent duplicate execution of actions when retries occur
@@ -5559,6 +5589,11 @@ class TunnelClient:
         }
         if self.remote_keepalive_for_main_id:
             headers["X-Remote-Keepalive-For"] = self.remote_keepalive_for_main_id
+        # Customer-supplied machine name (--name). Cyberdesk uses this to populate
+        # the Machine.name column, letting customers correlate parallel-provisioned
+        # VMs to dashboard rows without relying on cyberdesk's auto-generated id.
+        if self.machine_name:
+            headers["X-CYBERDRIVER-NAME"] = self.machine_name
         
         # Use compatibility wrapper for connection
         self._connection_attempt += 1
@@ -6401,7 +6436,8 @@ async def run_join(host: str, port: int, secret: str, target_port: int, keepaliv
                    keepalive_click_x: Optional[int] = None, keepalive_click_y: Optional[int] = None,
                    black_screen_recovery_enabled: bool = False,
                    black_screen_check_interval: float = 30.0,
-                   debug_enabled: bool = False):
+                   debug_enabled: bool = False,
+                   machine_name: Optional[str] = None):
     """Run both API server and tunnel client."""
     # Ensure default transfer directory exists for file operations during join.
     transfers_dir = pathlib.Path.home() / "CyberdeskTransfers"
@@ -6515,6 +6551,7 @@ async def run_join(host: str, port: int, secret: str, target_port: int, keepaliv
             keepalive_manager=keepalive_manager if keepalive_enabled else None,
             remote_keepalive_for_main_id=register_as_keepalive_for,
             internal_request_token=tunnel_internal_token,
+            machine_name=machine_name,
         )
 
     async def start_tunnel():
@@ -7184,6 +7221,16 @@ def main():
     join_parser.add_argument("--add-persistent-display", action="store_true", help="Install and enable Amyuni virtual display driver for persistent display (Windows only, requires admin)")
     join_parser.add_argument("--interactive", action="store_true", help="Interactive CLI to Disable/Re-enable without exiting")
     join_parser.add_argument("--register-as-keepalive-for", type=str, default=None, help="Register this instance as the remote keepalive (host) for MAIN_MACHINE_ID")
+    join_parser.add_argument(
+        "--name",
+        type=str,
+        default=None,
+        help=(
+            "Human-readable name for this machine (e.g. \"beacon-vm-12\"). "
+            "Sent to Cyberdesk on connect via the X-CYBERDRIVER-NAME header. "
+            "Useful for identifying machines provisioned in parallel from the same image."
+        ),
+    )
     join_parser.add_argument("--debug", action="store_true", help="Enable debug logging to ~/.cyberdriver/logs/ (daily log files)")
     join_parser.add_argument("--experimental-space", action="store_true", help="Send space key via VK code instead of scan code (may fix issues with some apps like Cerner)")
     join_parser.add_argument(
@@ -7570,7 +7617,19 @@ def main():
                 global debug_logger
                 debug_logger = DebugLogger.initialize(enabled=True)
                 print(f"✓ Debug logging enabled. Logs will be written to: {debug_logger.log_dir}")
-            
+
+            # Sanitize and surface the user-supplied machine name (if any) so it's
+            # visible in startup logs alongside other join-time settings.
+            raw_name = getattr(args, "name", None)
+            sanitized_name = sanitize_machine_name(raw_name)
+            if raw_name is not None and sanitized_name is None:
+                print(
+                    "Warning: --name value was empty or contained control characters; "
+                    "ignoring. Cyberdesk will assign a default name."
+                )
+            elif sanitized_name is not None:
+                print(f"✓ Machine name: {sanitized_name}")
+
             asyncio.run(run_join(
                 args.host,
                 args.port,
@@ -7585,6 +7644,7 @@ def main():
                 black_screen_recovery_enabled=bool(getattr(args, "black_screen_recovery", False)),
                 black_screen_check_interval=float(getattr(args, "black_screen_check_interval", 30.0)),
                 debug_enabled=debug_enabled,
+                machine_name=sanitized_name,
             ))
     except KeyboardInterrupt:
         print("\n\nKeyboard interrupt received. Shutting down...")

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -7465,10 +7465,11 @@ def main():
                         print("  " + "\n  ".join(excerpt.splitlines()[-12:]))
 
                     _print_founder_support_hint()
-                    print("")
-                    print(f"{bold}If the issue is transient, Cyberdriver will keep retrying on its own.{reset}")
-                    print(f"Stop it anytime with: {bold}cyberdriver stop{reset}")
-                    print("")
+                    if state in ("tls_failed", "timeout"):
+                        print("")
+                        print(f"{bold}If the issue is transient, Cyberdriver will keep retrying on its own.{reset}")
+                        print(f"Stop it anytime with: {bold}cyberdriver stop{reset}")
+                        print("")
 
             # Default UX: return immediately. If the user wants logs in this terminal,
             # they can opt-in with --tail.

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -1793,7 +1793,7 @@ async def connect_with_headers(uri, headers_dict):
 CONFIG_DIR = ".cyberdriver"
 CONFIG_FILE = "config.json"
 PID_FILE = "cyberdriver.pid.json"
-VERSION = "0.0.43"
+VERSION = "0.0.44"
 
 @dataclass
 class Config:

--- a/cyberdriver.py
+++ b/cyberdriver.py
@@ -86,7 +86,15 @@ import certifi
 import httpx
 import mss
 import numpy as np
-import pyautogui
+
+# pyautogui is lazy-imported (see _ensure_pyautogui below). On Linux it
+# transitively imports `mouseinfo`, which opens an Xlib `Display()` connection
+# at import time. In headless environments (CI, fresh containers, AMI bake
+# steps, `cyberdriver --help` on a freshly provisioned VM) that crashes before
+# argparse even runs - blocking basic CLI introspection. We only need
+# pyautogui for runtime commands (`join`, `coords`), so we defer the import to
+# those code paths. See CYB-207 / GH#50.
+pyautogui: Any = None  # populated by _ensure_pyautogui()
 import pyperclip
 from PIL import Image
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -2595,11 +2603,25 @@ def execute_xdo_sequence_state_change(sequence: str, down: bool):
 # PyAutoGUI Configuration
 # -----------------------------------------------------------------------------
 
-# Disable PyAutoGUI's default pause between commands for better performance
-pyautogui.PAUSE = 0
-# Disable fail-safe for virtual display environments (RustDesk, RDP, etc.)
-# where display changes can trigger false positives
-pyautogui.FAILSAFE = False
+def _ensure_pyautogui():
+    """Lazily import pyautogui and apply runtime config.
+
+    See the import-site comment for why this is deferred. Idempotent: safe to
+    call from multiple entry points (`run_join`, `run_coords_capture`). Raises
+    the underlying exception if the import fails so the caller surfaces a
+    clear startup error instead of a confusing AttributeError later.
+    """
+    global pyautogui
+    if pyautogui is not None:
+        return pyautogui
+    import pyautogui as _pa
+    # Disable PyAutoGUI's default pause between commands for better performance.
+    _pa.PAUSE = 0
+    # Disable fail-safe for virtual display environments (RustDesk, RDP, etc.)
+    # where display changes can trigger false positives.
+    _pa.FAILSAFE = False
+    pyautogui = _pa
+    return pyautogui
 
 
 def _get_env_float(name: str, default: float, minimum: float = 0.0) -> float:
@@ -6439,6 +6461,10 @@ async def run_join(host: str, port: int, secret: str, target_port: int, keepaliv
                    debug_enabled: bool = False,
                    machine_name: Optional[str] = None):
     """Run both API server and tunnel client."""
+    # Bring up pyautogui (see _ensure_pyautogui). On Linux this requires a
+    # working X display; failures here surface a real "no DISPLAY" error
+    # instead of an opaque AttributeError later in the request hot path.
+    _ensure_pyautogui()
     # Ensure default transfer directory exists for file operations during join.
     transfers_dir = pathlib.Path.home() / "CyberdeskTransfers"
     try:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -125,6 +125,7 @@ def _load_run_join_namespace(temp_home: Path, record: Dict[str, Any]):
             keepalive_manager=None,
             remote_keepalive_for_main_id=None,
             internal_request_token=None,
+            machine_name=None,
         ):
             record.setdefault("tunnels", []).append(
                 {
@@ -136,6 +137,7 @@ def _load_run_join_namespace(temp_home: Path, record: Dict[str, Any]):
                     "keepalive_manager": keepalive_manager,
                     "remote_keepalive_for_main_id": remote_keepalive_for_main_id,
                     "internal_request_token": internal_request_token,
+                    "machine_name": machine_name,
                 }
             )
 
@@ -426,6 +428,7 @@ class JoinFlowTests(unittest.TestCase):
             record["tunnels"][0]["internal_request_token"],
             "generated-tunnel-token",
         )
+        self.assertIsNone(record["tunnels"][0]["machine_name"])
         self.assertEqual(
             namespace["app"].state.tunnel_internal_token,
             "generated-tunnel-token",

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -181,6 +181,7 @@ def _load_run_join_namespace(temp_home: Path, record: Dict[str, Any]):
         "KeepAliveManager": _KeepAliveManager,
         "BlackScreenRecoveryManager": _BlackScreenRecoveryManager,
         "TunnelClient": _TunnelClient,
+        "_ensure_pyautogui": lambda: None,
         "_set_connection_info": _fake_set_connection_info,
         "pathlib": types.SimpleNamespace(Path=_PathProxy),
         "print": lambda *args, **kwargs: None,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the `join` connection path by adding a new handshake header and input validation, which could affect connectivity if misapplied. Also changes import timing for `pyautogui`, potentially surfacing new runtime errors in environments that previously only failed later.
> 
> **Overview**
> Adds optional machine naming to `cyberdriver join` via `--name`, validating/sanitizing it (printable ASCII, trimmed, max 128) and propagating it to Cyberdesk as `X-CYBERDRIVER-NAME` on the WebSocket handshake.
> 
> Fixes a Linux/headless crash by lazy-importing `pyautogui` (and applying its runtime config in `_ensure_pyautogui()`), invoked at `join` startup; bumps version to `0.0.44` and updates tests/docs accordingly. Also tweaks retry UX messaging to only suggest “keeps retrying” for specific transient states (`tls_failed`, `timeout`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f814edae5d52d856f91887ff4e8e4d212d8a764f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->